### PR TITLE
Test single slice

### DIFF
--- a/examples/Cluster_stab.jl
+++ b/examples/Cluster_stab.jl
@@ -1,5 +1,5 @@
 using Pkg
-Pkg.activate("..")
+Pkg.activate(".")
 include("../src/functions.jl");
 
 @var κ[1:6] x[1:2] T[1:2]
@@ -24,17 +24,17 @@ projection_vars = [κ; T]  # These are the variables we are projecting to.
 k = 8
 B = qr(rand(k, k)).Q |> Matrix
 c = 10 .* randn(k)
-
-PWS = PseudoWitnessSet(F, k; linear_subspace_codim = k - 1)
+F_ordered = System(F.expressions, variables = [projection_vars; x])
+PWS = PseudoWitnessSet(F_ordered, k; linear_subspace_codim = k - 1)
 e = Int(floor(degree(PWS) / 2)) + 1
 
-F_ordered = System(F.expressions, variables = [projection_vars; x])
+
 
 hess_off_diag = hess_log_r(F_ordered, e, projection_vars; method = :off_diag, c, B)
 hess_many_slices = hess_log_r(F_ordered, e, projection_vars; method = :many_slices, c, B)
-
+hess_single_slice = hess_log_r(F_ordered, e, projection_vars; method = :single_slice, c, B)
 p = rand(k)
-H_od = hess_off_diag(p)
-H_ms = hess_many_slices(p)
-
-norm(H_od - H_ms)
+@time H_od = hess_off_diag(p)
+@time H_ms = hess_many_slices(p)
+@time H_ss = hess_single_slice(p)
+norm(H_od - H_ss)

--- a/examples/host_range.jl
+++ b/examples/host_range.jl
@@ -1,0 +1,81 @@
+using Pkg
+Pkg.activate(".")
+using HomotopyContinuation, LinearAlgebra, DifferentialEquations
+include("../src/functions.jl")
+#Example host-range expansion. 3 dimensional system from this paper: https://epubs.siam.org/doi/10.1137/23M1605582
+
+
+#Setting up the system (cleared denominators) here we have that κ_i=1/K_i where K_i is the carrying capacity of species i
+@var N[1:2] P r[1:2] κ[1:2] β λ 
+
+DE_eqs = [r[1]*N[1]*(1-N[1]*κ[1])-N[1]*N[2]-N[1]*P,
+          r[2]*N[2]*(1-N[1]*κ[1])-N[2]*N[1],
+          β*N[1]*P-P
+    ]
+
+#adding the condition that solutions to the system are singular
+J=differentiate(vcat(DE_eqs),vcat(N,P))
+
+#getting the characteristic polynomial 
+char=det(λ*I-J)
+
+
+#getting the coeffs of the characteristic poly 
+#to use in the Routh array
+
+coeffs=coefficients(char,λ)
+
+#Explicitly constructing the Hurwitz matrix
+#(there is definitely a more clever way to do this)
+
+hurwitz = zeros(Expression, 3, 3)
+
+a_3=coeffs[1]
+a_2=coeffs[2]
+a_1=coeffs[3]
+a_0=coeffs[4]
+
+hurwitz[1,1]=a_2
+hurwitz[1,2]=a_0 
+hurwitz[2,1]=a_3 
+hurwitz[2,2]=a_1
+hurwitz[3,2]=a_2
+hurwitz[3,3]=a_0
+
+
+#Routh_Hurwitz polynomials are the principal minors of the Hurwitz matrix
+minors = Expression[]
+for i in 1:3
+    minor = det(hurwitz[1:i, 1:i])
+    push!(minors, minor)
+end
+
+RH_boundary_eqs = minors[1]*minors[3]
+
+#System for the incidence variety of the hypersurface
+F = System(vcat(DE_eqs,RH_boundary_eqs), variables = vcat(β, r, κ, N, P))
+
+projection_variables = [β; r; κ]
+k = length(projection_variables)
+
+B = qr(rand(k, k)).Q |> Matrix
+c = 10 .* randn(k)
+F_ordered = System(F.expressions, variables = [projection_variables; N; P])
+
+PWS = PseudoWitnessSet(F_ordered, k; linear_subspace_codim = k - 1)
+
+e = Int(floor(degree(PWS) / 2)) + 1
+
+#testing hessian methods
+
+hess_off_diag = hess_log_r(F_ordered, e, projection_variables; method = :off_diag, c, B)
+hess_many_slices = hess_log_r(F_ordered, e, projection_variables; method = :many_slices, c, B)
+hess_single_slice = hess_log_r(F_ordered, e, projection_variables; method = :single_slice, c, B)
+
+P = rand(k)
+
+@time hess_off_diag_eval = hess_off_diag(P)
+@time hess_many_slices_eval = hess_many_slices(P) 
+@time hess_single_slice_eval = hess_single_slice(P) 
+
+norm(hess_off_diag_eval - hess_single_slice_eval) # should be small, and is about 1e-7

--- a/single_slice_test.jl
+++ b/single_slice_test.jl
@@ -29,9 +29,98 @@ h = a^2-4*b
 hess_given_h = hess_log_r_given_h(h,e;c)
 P = rand(k)
 
-#the single slice method is currently inaccurate and allocates a lot of memory
-#we will have to optimize this.  
-@time hess_off_diag_eval = hess_off_diag(P)
-@time hess_single_slice_eval = hess_single_slice(P)
-@time hess_many_slices_eval = hess_many_slices(P)
+#single slice method is slower on this example. 
+@time hess_off_diag_eval = hess_off_diag(P) #1.15 seconds on first run, 0.00096 seconds on second run (on my machine)
+@time hess_single_slice_eval = hess_single_slice(P) #3.07 seconds on first run, 0.00424 on second run (on my machine)
+@time hess_many_slices_eval = hess_many_slices(P) #0.97 seconds on first run, 0.0018 seconds on second run (on my machine)
 @time hess_given_h_eval = hess_given_h(P)
+
+norm(hess_given_h_eval - hess_single_slice_eval) # should be small, and is about 1e-14
+
+#Testing on larger examples (cluster stabilization)
+@var κ[1:6] x[1:2] T[1:2]
+
+# κ chemical reaction rate coefficients
+# T conservation constants (total amounts)
+# x chemical concentrations
+Clus_Eq = [
+    x[1] + x[2] - T[1] - T[2],
+    -κ[1] * x[1]^3 * x[2] - 2 * κ[2] * x[1]^3 * x[2] - 3 * κ[3] * x[1]^3 * x[2] -
+    κ[4] * x[1]^3 * x[2]^2 - 2 * κ[5] * x[1]^2 * x[2]^2 - κ[6]x[1] * x[2]^3,
+]
+# Equations of Cluster Stabilization Model 
+# Example 3.1 from https://www.sciencedirect.com/science/article/pii/S0196885821000920
+
+Jac = differentiate(Clus_Eq, [x[1], x[2]])
+
+dJ = det(Jac)
+
+F = System([Clus_Eq; dJ], variables = [κ; T; x])
+projection_vars = [κ; T]  # These are the variables we are projecting to.
+
+k = 8
+B = qr(rand(k, k)).Q |> Matrix
+c = 10 .* randn(k)
+F_ordered = System(F.expressions, variables = [projection_vars; x])
+PWS = PseudoWitnessSet(F_ordered, k; linear_subspace_codim = k - 1)
+e = Int(floor(degree(PWS) / 2)) + 1
+
+
+
+hess_off_diag = hess_log_r(F_ordered, e, projection_vars; method = :off_diag, c, B)
+hess_many_slices = hess_log_r(F_ordered, e, projection_vars; method = :many_slices, c, B)
+hess_single_slice = hess_log_r(F_ordered, e, projection_vars; method = :single_slice, c, B)
+p = rand(k)
+
+#on this example, single slice is faster than off_diag and many_slices. but it still allocates more memory than off_diag.
+@time H_od = hess_off_diag(p) #0.219 seconds (on my machine), 13.84k allocations
+@time H_ms = hess_many_slices(p) #0.085 seconds (on my machine), 108.03k allocations 
+@time H_ss = hess_single_slice(p) #0.051 seconds (on my machine) 100.15k allocations
+norm(H_od - H_ss) #still very small, on the order of 1e-10
+
+
+
+
+# Another example, this time the four bus example 
+# In this lossless four bus system with zero power injections, we have 6 parameters (6 bij where i\neq j) and 6 variables (Vd[1:3], Vq[1:3])
+@var b[1:4, 1:4] Vd[1:4] Vq[1:4] 
+#Vd is real component of voltage
+#Vq is imaginary component of voltage
+#b the susceptance of the line connecting buses i and k
+eqn2_2a =
+    sum.([[b[i, k] * (Vd[k] * Vq[i] - Vd[i] * Vq[k]) for k = 2:4 if i != k] for i = 2:4]) + [Vq[i] * b[1, i] for i = 2:4]
+bus_eqns = [
+    eqn2_2a
+    Vd[2:4] .^ 2 - Vq[2:4] .^ 2 - ones(3)
+]
+#Note that b[i,k] == b[k,i]. As such, only keep one. 
+bus_eqns = subs(bus_eqns, b[2,1]=> b[1,2], b[3,1]=> b[1,3], b[4,1]=> b[1,4], b[3,2]=> b[2,3], b[4,2]=> b[2,4], b[4,3]=> b[3,4])
+Jac = differentiate(bus_eqns, [Vd[2:4]; Vq[2:4]])
+D = det(Jac)
+
+F = System([bus_eqns; D])
+# System for the incidence variety of the discriminant
+all_vars = variables(F)
+x_vars = [Vd[2:4]; Vq[2:4]]
+projection_vars = setdiff(all_vars, x_vars)
+F_ordered = System(F.expressions, variables = [projection_vars; x_vars])
+k = length(projection_vars)
+PWS = PseudoWitnessSet(F_ordered, k; linear_subspace_codim = k - 1)
+
+d = degree(PWS)
+e= Int(floor(d/2)+1)
+B = qr(rand(k, k)).Q |> Matrix
+c = 10 .* randn(k)
+######################################################
+#Testing our hessian methods
+hess_off_diag = hess_log_r(F_ordered, e, projection_vars; method = :off_diag, c, B)
+hess_many_slices = hess_log_r(F_ordered, e, projection_vars; method = :many_slices, c, B)
+hess_single_slice = hess_log_r(F_ordered, e, projection_vars; method = :single_slice, c, B)
+
+
+#This is an example where the mysterious bug mentioned in the TODO list occurs. 
+#The optimized single_slice method (using caching) is subject to this bug as well. 
+P = rand(k)
+@time hess_off_diag_eval = hess_off_diag(P)
+@time hess_many_slices_eval = hess_many_slices(P)
+@time hess_single_slice_eval = hess_single_slice(P)

--- a/single_slice_test.jl
+++ b/single_slice_test.jl
@@ -37,6 +37,10 @@ P = rand(k)
 
 norm(hess_given_h_eval - hess_single_slice_eval) # should be small, and is about 1e-14
 
+
+###############################################################################################################
+###############################################################################################################
+
 #Testing on larger examples (cluster stabilization)
 @var κ[1:6] x[1:2] T[1:2]
 
@@ -75,11 +79,93 @@ p = rand(k)
 #on this example, single slice is faster than off_diag and many_slices. but it still allocates more memory than off_diag.
 @time H_od = hess_off_diag(p) #0.219 seconds (on my machine), 13.84k allocations
 @time H_ms = hess_many_slices(p) #0.085 seconds (on my machine), 108.03k allocations 
-@time H_ss = hess_single_slice(p) #0.051 seconds (on my machine) 91.15k allocations
+@time H_ss = hess_single_slice(p) #0.051 seconds (on my machine) 51.34k allocations
 norm(H_od - H_ss) #still very small, on the order of 1e-12
 
+###############################################################################################################
+###############################################################################################################
 
 
+#Example host-range expansion. 3 dimensional system from this paper: https://epubs.siam.org/doi/10.1137/23M1605582
+
+
+#Setting up the system (cleared denominators) here we have that κ_i=1/K_i where K_i is the carrying capacity of species i
+@var N[1:2] P r[1:2] κ[1:2] β λ 
+
+DE_eqs = [r[1]*N[1]*(1-N[1]*κ[1])-N[1]*N[2]-N[1]*P,
+          r[2]*N[2]*(1-N[1]*κ[1])-N[2]*N[1],
+          β*N[1]*P-P
+    ]
+
+#adding the condition that solutions to the system are singular
+J=differentiate(vcat(DE_eqs),vcat(N,P))
+
+#getting the characteristic polynomial 
+char=det(λ*I-J)
+
+
+#getting the coeffs of the characteristic poly 
+#to use in the Routh array
+
+coeffs=coefficients(char,λ)
+
+#Explicitly constructing the Hurwitz matrix
+#(there is definitely a more clever way to do this)
+
+hurwitz = zeros(Expression, 3, 3)
+
+a_3=coeffs[1]
+a_2=coeffs[2]
+a_1=coeffs[3]
+a_0=coeffs[4]
+
+hurwitz[1,1]=a_2
+hurwitz[1,2]=a_0 
+hurwitz[2,1]=a_3 
+hurwitz[2,2]=a_1
+hurwitz[3,2]=a_2
+hurwitz[3,3]=a_0
+
+
+#Routh_Hurwitz polynomials are the principal minors of the Hurwitz matrix
+minors = Expression[]
+for i in 1:3
+    minor = det(hurwitz[1:i, 1:i])
+    push!(minors, minor)
+end
+
+RH_boundary_eqs = minors[1]*minors[3]
+
+#System for the incidence variety of the hypersurface
+F = System(vcat(DE_eqs,RH_boundary_eqs), variables = vcat(β, r, κ, N, P))
+
+projection_variables = [β; r; κ]
+k = length(projection_variables)
+
+B = qr(rand(k, k)).Q |> Matrix
+c = 10 .* randn(k)
+F_ordered = System(F.expressions, variables = [projection_variables; N; P])
+
+PWS = PseudoWitnessSet(F_ordered, k; linear_subspace_codim = k - 1)
+
+e = Int(floor(degree(PWS) / 2)) + 1
+
+#testing hessian methods
+
+hess_off_diag = hess_log_r(F_ordered, e, projection_variables; method = :off_diag, c, B)
+hess_many_slices = hess_log_r(F_ordered, e, projection_variables; method = :many_slices, c, B)
+hess_single_slice = hess_log_r(F_ordered, e, projection_variables; method = :single_slice, c, B)
+
+P = rand(k)
+
+@time hess_off_diag_eval = hess_off_diag(P) #around 0.19 seconds (on my machine), 9.47k allocations
+@time hess_many_slices_eval = hess_many_slices(P) #around 0.09 seconds (on my machine), 216.49k allocations
+@time hess_single_slice_eval = hess_single_slice(P) #around 0.22 seconds (on my machine), 434.48k allocations
+
+norm(hess_off_diag_eval - hess_single_slice_eval) # should be small, and is about 1e-7
+
+#######################################################################################
+#######################################################################################
 
 # Another example, this time the four bus example 
 # In this lossless four bus system with zero power injections, we have 6 parameters (6 bij where i\neq j) and 6 variables (Vd[1:3], Vq[1:3])

--- a/single_slice_test.jl
+++ b/single_slice_test.jl
@@ -75,8 +75,8 @@ p = rand(k)
 #on this example, single slice is faster than off_diag and many_slices. but it still allocates more memory than off_diag.
 @time H_od = hess_off_diag(p) #0.219 seconds (on my machine), 13.84k allocations
 @time H_ms = hess_many_slices(p) #0.085 seconds (on my machine), 108.03k allocations 
-@time H_ss = hess_single_slice(p) #0.051 seconds (on my machine) 100.15k allocations
-norm(H_od - H_ss) #still very small, on the order of 1e-10
+@time H_ss = hess_single_slice(p) #0.051 seconds (on my machine) 91.15k allocations
+norm(H_od - H_ss) #still very small, on the order of 1e-12
 
 
 

--- a/src/gradient_hessian.jl
+++ b/src/gradient_hessian.jl
@@ -14,7 +14,7 @@ function GradientCache(PWS; single_slice = false)
 
     if single_slice
         Ks = Vector{LinearSubspace}(undef, 1)
-        line_hypersurface_intersections = [zeros(ComplexF64, n) for _ in 1:d]
+        line_hypersurface_intersections = [[zeros(ComplexF64, n) for _ in 1:d]]
     else
         Ks = Vector{LinearSubspace}(undef, k)
         line_hypersurface_intersections = [[zeros(ComplexF64, n) for _ = 1:d] for _ = 1:k]
@@ -387,18 +387,17 @@ function _single_slice(
         fill!(hess1, 0)
         fill!(hess2, 0)
 
-        track_pws_to_line!(GC, P, B, PWS)
-        # L_target = lifted_line(P, B, n)
-        # list_of_solutions = solutions(HC.solve(PWS.F, PWS.W, start_subspace=PWS.L, target_subspace=L_target, intrinsic=true))
-        # S = zeros(ComplexF64, length(GC.line_hypersurface_intersections))
-        # U = zeros(ComplexF64, n - k, length(GC.line_hypersurface_intersections))
-        for (j, sol) in enumerate(GC.line_hypersurface_intersections)
+        # Compute the intersection points through a pseudowitness set
+        track_pws_to_lines!(GC, P, B, PWS)
+        #Obtain U and the projection S
+        for (j, sol) in enumerate(GC.line_hypersurface_intersections[1])
             X = sol[1:k]
             U[:, j] = sol[k+1:end]
             _, nonzero_coordinate = findmax(abs, X - P)
             S[j] = (X[nonzero_coordinate] - P[nonzero_coordinate]) / B[nonzero_coordinate]
         end
 
+        #Obtain gradients of S and U with respect to p and β
         for i = 1:length(S)
             if typeof(JsuF) == Matrix{Expression}
                 Jsu = evaluate(JsuF, vcat(t, u, p) => vcat(S[i], U[:, i], P)) 
@@ -415,21 +414,18 @@ function _single_slice(
             else 
                 JB = JBF
             end
-            # solution_p = -Jsu \ JP # solves the system Jsu*sol_p = -JP
-            # solution_b = -Jsu \ JB # solves the system Jsu*sol_b = -JB
+
             PBsols = -Jsu \ [JP JB] # solves the system Jsu*A = -[JP JB]
-            # SP[i, :] = solution_p[1, :]
-            # SB[i, :] = solution_b[1, :]
+
             SP[i,:] = PBsols[1, 1:k]
             SB[i,:] = PBsols[1, k+1:end]
-            # UP[i, :, :] = solution_p[2:end, :]
-            # UB[i, :, :] = solution_b[2:end, :]
+
             UP[i,:,:] = PBsols[2:end, 1:k]
             UB[i,:,:] = PBsols[2:end, k+1:end]
         end
 
-        # Compute second-order Jacobians of s and use this to estimate the Hessian
-        for i = 1:length(F_on_line)# loop through every equation in F?
+        # Computation outlined in the abstract description Jon gave in Overleaf file
+        for i = 1:length(F_on_line)
             for j = 1:length(S)
                 if typeof(HF[i]) == Matrix{Expression}
                     H = evaluate(HF[i], vcat(t, u, p) => vcat(S[j], U[:, j], P))
@@ -459,6 +455,7 @@ function _single_slice(
             end
         end
         
+        #Compute Hessian
         for j = 1:length(S)
             if typeof(JsuF) == Matrix{Expression}
                 Jtu = evaluate(JsuF, vcat(t, u, p) => vcat(S[j], U[:, j], P)) 

--- a/src/gradient_hessian.jl
+++ b/src/gradient_hessian.jl
@@ -20,7 +20,7 @@ function GradientCache(PWS; single_slice = false)
         line_hypersurface_intersections = [[zeros(ComplexF64, n) for _ = 1:d] for _ = 1:k]
     end
 
-    Hom = linear_subspace_homotopy(F, PWS.L, PWS.L; intrinsic = true)
+    Hom = linear_subspace_homotopy(PWS.F, PWS.L, PWS.L; intrinsic = true)
     tracker = EndgameTracker(Hom)
 
     grad = zeros(ComplexF64, k)

--- a/src/gradient_hessian.jl
+++ b/src/gradient_hessian.jl
@@ -6,13 +6,18 @@ mutable struct GradientCache
     H::Matrix
 end
 
-function GradientCache(PWS)
+function GradientCache(PWS; single_slice = false)
     n = ambient_dim(PWS)
     d = degree(PWS)
     k = n_projection_variables(PWS)
 
-    Ks = Vector{LinearSubspace}(undef, k)
-    line_hypersurface_intersections = [[zeros(ComplexF64, n) for _ = 1:d] for _ = 1:k]
+    if single_slice
+        Ks = Vector{LinearSubspace}(undef, 1)
+        line_hypersurface_intersections = [zeros(ComplexF64, n) for _ in 1:d]
+    else
+        Ks = Vector{LinearSubspace}(undef, k)
+        line_hypersurface_intersections = [[zeros(ComplexF64, n) for _ = 1:d] for _ = 1:k]
+    end
 
     Hom = linear_subspace_homotopy(F, PWS.L, PWS.L; intrinsic = true)
     tracker = EndgameTracker(Hom)
@@ -323,18 +328,6 @@ function _many_slices(
 
 end
 
-# function _single_slice(
-#     F::System,
-#     PWS::PseudoWitnessSet,
-#     e,
-#     projection_vars::Vector{Variable};
-#     c::Union{AbstractVector,Nothing} = nothing,
-#     B::Union{Matrix,Nothing} = nothing,
-# )
-#     # TODO: This needs to be implemented! For now, redirect to the off_diag method.
-#     hess_log_r(PWS, e; c, B)
-# end
-
 
 
 function _single_slice(
@@ -359,6 +352,9 @@ function _single_slice(
     JPF = differentiate(F_on_line, p) #Jacobian of F with respect to p
     JBF = differentiate(F_on_line, β) #Jacobian of F with respect to \beta
 
+
+    GC = GradientCache(PWS; single_slice = true)
+
     # Set up function for hess(q)
     q = 1 + sum((p - c) .* (p - c))
     Hlogqe(pt) = evaluate(differentiate(differentiate(log(q^e), p), p), p => pt) 
@@ -367,8 +363,11 @@ function _single_slice(
         # Compute the intersection points through a pseudowitness set
         # TODO: Use gradient cache for this 
         # The tracking function would need to be adapted to the case of a single direction
-        L_target = lifted_line(P, B, n)
-        list_of_solutions = solutions(HC.solve(PWS.F, PWS.W, start_subspace=PWS.L, target_subspace=L_target, intrinsic=true))
+
+        track_pws_to_line!(GC, P, B, PWS)
+        list_of_solutions = GC.line_hypersurface_intersections
+        # L_target = lifted_line(P, B, n)
+        # list_of_solutions = solutions(HC.solve(PWS.F, PWS.W, start_subspace=PWS.L, target_subspace=L_target, intrinsic=true))
         S = zeros(ComplexF64, length(list_of_solutions))
         U = zeros(ComplexF64, n - k, length(list_of_solutions))
         for (j, sol) in enumerate(list_of_solutions)

--- a/src/gradient_hessian.jl
+++ b/src/gradient_hessian.jl
@@ -4,6 +4,7 @@ mutable struct GradientCache
     tracker::EndgameTracker
     v::Vector
     H::Matrix
+
 end
 
 function GradientCache(PWS; single_slice = false)
@@ -352,25 +353,47 @@ function _single_slice(
     JPF = differentiate(F_on_line, p) #Jacobian of F with respect to p
     JBF = differentiate(F_on_line, β) #Jacobian of F with respect to \beta
 
+    #Symbolic Hessians
+    HF = [differentiate(differentiate(F_on_line[i], vcat(t, u)), vcat(t, u)) for i in 1:N]
+    JxB = [differentiate(differentiate(F_on_line[i], vcat(t, u)), β) for i in 1:N]
+    JxP = [differentiate(differentiate(F_on_line[i], vcat(t, u)), p) for i in 1:N]
+    JPB = [differentiate(differentiate(F_on_line[i], p), β) for i in 1:N]
 
     GC = GradientCache(PWS; single_slice = true)
+    
+    d= degree(PWS) 
+    #Initializing several variables for use in the function
+    S = zeros(ComplexF64, d)
+    U = zeros(ComplexF64, n - k, d)
+
+    SP = zeros(ComplexF64, length(S), k) 
+    SB = zeros(ComplexF64, length(S), k)
+    UP = zeros(ComplexF64, length(S), n - k, k)
+    UB = zeros(ComplexF64, length(S), n - k, k)
+
+    A = zeros(ComplexF64, length(S), size(F_on_line, 1), k, k)
+
+    hess1 = zeros(ComplexF64, k, k)
+    hess2 = zeros(ComplexF64, k, k)
 
     # Set up function for hess(q)
     q = 1 + sum((p - c) .* (p - c))
     Hlogqe(pt) = evaluate(differentiate(differentiate(log(q^e), p), p), p => pt) 
 
     function f(P) 
+
+        fill!(hess1, 0)
+        fill!(hess2, 0)
         # Compute the intersection points through a pseudowitness set
         # TODO: Use gradient cache for this 
         # The tracking function would need to be adapted to the case of a single direction
 
         track_pws_to_line!(GC, P, B, PWS)
-        list_of_solutions = GC.line_hypersurface_intersections
         # L_target = lifted_line(P, B, n)
         # list_of_solutions = solutions(HC.solve(PWS.F, PWS.W, start_subspace=PWS.L, target_subspace=L_target, intrinsic=true))
-        S = zeros(ComplexF64, length(list_of_solutions))
-        U = zeros(ComplexF64, n - k, length(list_of_solutions))
-        for (j, sol) in enumerate(list_of_solutions)
+        # S = zeros(ComplexF64, length(GC.line_hypersurface_intersections))
+        # U = zeros(ComplexF64, n - k, length(GC.line_hypersurface_intersections))
+        for (j, sol) in enumerate(GC.line_hypersurface_intersections)
             X = sol[1:k]
             U[:, j] = sol[k+1:end]
             _, nonzero_coordinate = findmax(abs, X - P)
@@ -378,10 +401,10 @@ function _single_slice(
         end
 
         # Compute first-order Jacobians of s and u
-        SP = zeros(ComplexF64, length(S), k) 
-        SB = zeros(ComplexF64, length(S), k)
-        UP = zeros(ComplexF64, length(S), n - k, k)
-        UB = zeros(ComplexF64, length(S), n - k, k)
+        # SP = zeros(ComplexF64, length(S), k) 
+        # SB = zeros(ComplexF64, length(S), k)
+        # UP = zeros(ComplexF64, length(S), n - k, k)
+        # UB = zeros(ComplexF64, length(S), n - k, k)
         for i = 1:length(S)
             Jsu = evaluate(JsuF, vcat(t, u, p, β) => vcat(S[i], U[:, i], P, B)) 
             JP = evaluate(JPF, vcat(t, u, p, β) => vcat(S[i], U[:, i], P, B))
@@ -395,17 +418,13 @@ function _single_slice(
         end
 
         # Compute second-order Jacobians of s and use this to estimate the Hessian
-        A = zeros(ComplexF64, length(S), size(F_on_line, 1), k, k)
+        # A = zeros(ComplexF64, length(S), size(F_on_line, 1), k, k)
         for i = 1:length(F_on_line)# loop through every equation in F?
-            HF = differentiate(differentiate(F_on_line[i], vcat(t, u)), vcat(t, u))
-            JxB = differentiate(differentiate(F_on_line[i], vcat(t, u)), β)
-            JxP = differentiate(differentiate(F_on_line[i], vcat(t, u)), p)
-            JPB = differentiate(differentiate(F_on_line[i], p), β)
             for j = 1:length(S)
-                H = evaluate(HF, vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
-                Jxb = evaluate(JxB, vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
-                Jxp = evaluate(JxP, vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
-                Jpb = evaluate(JPB, vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
+                H = evaluate(HF[i], vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
+                Jxb = evaluate(JxB[i], vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
+                Jxp = evaluate(JxP[i], vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
+                Jpb = evaluate(JPB[i], vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
                 A[j, i, :, :] = ([SP[j, :] transpose(UP[j, :, :])] * H * transpose([SB[j, :] transpose(UB[j, :, :])])
                                 + Jpb + [SP[j, :] transpose(UP[j, :, :])] * Jxb
                                 + transpose(Jxp) * transpose([SB[j, :] transpose(UB[j, :, :])])) |> transpose |> Matrix
@@ -413,8 +432,8 @@ function _single_slice(
             end
         end
         
-        hess1 = zeros(ComplexF64, k, k)
-        hess2 = zeros(ComplexF64, k, k)
+        # hess1 = zeros(ComplexF64, k, k)
+        # hess2 = zeros(ComplexF64, k, k)
         for j = 1:length(S)
             Jtu = evaluate(JsuF, vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
             sols = zeros(ComplexF64, k, k)
@@ -425,8 +444,8 @@ function _single_slice(
             hess1 = hess1 - 2 * S[j]^(-3) * SP[j, :] * transpose(SB[j, :])
             hess2 = hess2 + S[j]^(-2) * sols
         end
-        hess = hess1 + hess2 + Hlogqe(P) 
-        real(hess)
+        GC.H = hess1 + hess2 - Hlogqe(P) 
+        real(GC.H)
     end
     f
 end

--- a/src/gradient_hessian.jl
+++ b/src/gradient_hessian.jl
@@ -348,16 +348,18 @@ function _single_slice(
     N = length(F_on_line)
     @assert N == n-k+1 "Unexpected length of system"
 
-    # Symbolic Jacobians
-    JsuF = differentiate(F_on_line, vcat(t, u[:])) #Jacobian of F with respect to s and u
-    JPF = differentiate(F_on_line, p) #Jacobian of F with respect to p
-    JBF = differentiate(F_on_line, β) #Jacobian of F with respect to \beta
+    #since B remains the same no matter what P, it makes sense to evaluate
+    #the symbolic expressions at B here instead of when the function f(P) is called
+    # Symbolic Jacobians (except evaluated at β = B)
+    JsuF = evaluate(differentiate(F_on_line, vcat(t, u[:])), β => B) #Jacobian of F with respect to s and u
+    JPF = evaluate(differentiate(F_on_line, p), β => B) #Jacobian of F with respect to p
+    JBF = evaluate(differentiate(F_on_line, β), β => B) #Jacobian of F with respect to \beta
 
-    #Symbolic Hessians
-    HF = [differentiate(differentiate(F_on_line[i], vcat(t, u)), vcat(t, u)) for i in 1:N]
-    JxB = [differentiate(differentiate(F_on_line[i], vcat(t, u)), β) for i in 1:N]
-    JxP = [differentiate(differentiate(F_on_line[i], vcat(t, u)), p) for i in 1:N]
-    JPB = [differentiate(differentiate(F_on_line[i], p), β) for i in 1:N]
+    #Symbolic Hessians (except evaluated at β = B)
+    HF = [evaluate(differentiate(differentiate(F_on_line[i], vcat(t, u)), vcat(t, u)), β => B) for i in 1:N]
+    JxB = [evaluate(differentiate(differentiate(F_on_line[i], vcat(t, u)), β), β => B) for i in 1:N]
+    JxP = [evaluate(differentiate(differentiate(F_on_line[i], vcat(t, u)), p), β => B) for i in 1:N]
+    JPB = [evaluate(differentiate(differentiate(F_on_line[i], p), β), β => B) for i in 1:N]
 
     GC = GradientCache(PWS; single_slice = true)
     
@@ -384,9 +386,6 @@ function _single_slice(
 
         fill!(hess1, 0)
         fill!(hess2, 0)
-        # Compute the intersection points through a pseudowitness set
-        # TODO: Use gradient cache for this 
-        # The tracking function would need to be adapted to the case of a single direction
 
         track_pws_to_line!(GC, P, B, PWS)
         # L_target = lifted_line(P, B, n)
@@ -400,31 +399,59 @@ function _single_slice(
             S[j] = (X[nonzero_coordinate] - P[nonzero_coordinate]) / B[nonzero_coordinate]
         end
 
-        # Compute first-order Jacobians of s and u
-        # SP = zeros(ComplexF64, length(S), k) 
-        # SB = zeros(ComplexF64, length(S), k)
-        # UP = zeros(ComplexF64, length(S), n - k, k)
-        # UB = zeros(ComplexF64, length(S), n - k, k)
         for i = 1:length(S)
-            Jsu = evaluate(JsuF, vcat(t, u, p, β) => vcat(S[i], U[:, i], P, B)) 
-            JP = evaluate(JPF, vcat(t, u, p, β) => vcat(S[i], U[:, i], P, B))
-            JB = evaluate(JBF, vcat(t, u, p, β) => vcat(S[i], U[:, i], P, B))
-            solution_p = -Jsu \ JP # solves the system Jsu*sol_p = -JP
-            solution_b = -Jsu \ JB # solves the system Jsu*sol_b = -JB
-            SP[i, :] = solution_p[1, :]
-            SB[i, :] = solution_b[1, :]
-            UP[i, :, :] = solution_p[2:end, :]
-            UB[i, :, :] = solution_b[2:end, :]
+            if typeof(JsuF) == Matrix{Expression}
+                Jsu = evaluate(JsuF, vcat(t, u, p) => vcat(S[i], U[:, i], P)) 
+            else
+                Jsu = JsuF
+            end
+            if typeof(JPF) == Matrix{Expression}
+                JP = evaluate(JPF, vcat(t, u, p) => vcat(S[i], U[:, i], P))
+            else 
+                JP = JPF
+            end
+            if typeof(JBF) == Matrix{Expression}
+                JB = evaluate(JBF, vcat(t, u, p) => vcat(S[i], U[:, i], P))
+            else 
+                JB = JBF
+            end
+            # solution_p = -Jsu \ JP # solves the system Jsu*sol_p = -JP
+            # solution_b = -Jsu \ JB # solves the system Jsu*sol_b = -JB
+            PBsols = -Jsu \ [JP JB] # solves the system Jsu*A = -[JP JB]
+            # SP[i, :] = solution_p[1, :]
+            # SB[i, :] = solution_b[1, :]
+            SP[i,:] = PBsols[1, 1:k]
+            SB[i,:] = PBsols[1, k+1:end]
+            # UP[i, :, :] = solution_p[2:end, :]
+            # UB[i, :, :] = solution_b[2:end, :]
+            UP[i,:,:] = PBsols[2:end, 1:k]
+            UB[i,:,:] = PBsols[2:end, k+1:end]
         end
 
         # Compute second-order Jacobians of s and use this to estimate the Hessian
-        # A = zeros(ComplexF64, length(S), size(F_on_line, 1), k, k)
         for i = 1:length(F_on_line)# loop through every equation in F?
             for j = 1:length(S)
-                H = evaluate(HF[i], vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
-                Jxb = evaluate(JxB[i], vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
-                Jxp = evaluate(JxP[i], vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
-                Jpb = evaluate(JPB[i], vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
+                if typeof(HF[i]) == Matrix{Expression}
+                    H = evaluate(HF[i], vcat(t, u, p) => vcat(S[j], U[:, j], P))
+                else
+                    H = HF[i]
+                end
+                if typeof(JxB[i]) == Matrix{Expression}
+                    Jxb = evaluate(JxB[i], vcat(t, u, p) => vcat(S[j], U[:, j], P))
+                else
+                    Jxb = JxB[i]
+                end
+                if typeof(JxP[i]) == Matrix{Expression}
+                    Jxp = evaluate(JxP[i], vcat(t, u, p) => vcat(S[j], U[:, j], P))
+                else
+                    Jxp = JxP[i]
+                end
+                if typeof(JPB[i]) == Matrix{Expression}
+                    Jpb = evaluate(JPB[i], vcat(t, u, p) => vcat(S[j], U[:, j], P))
+                else
+                    Jpb = JPB[i]
+                end
+
                 A[j, i, :, :] = ([SP[j, :] transpose(UP[j, :, :])] * H * transpose([SB[j, :] transpose(UB[j, :, :])])
                                 + Jpb + [SP[j, :] transpose(UP[j, :, :])] * Jxb
                                 + transpose(Jxp) * transpose([SB[j, :] transpose(UB[j, :, :])])) |> transpose |> Matrix
@@ -432,10 +459,12 @@ function _single_slice(
             end
         end
         
-        # hess1 = zeros(ComplexF64, k, k)
-        # hess2 = zeros(ComplexF64, k, k)
         for j = 1:length(S)
-            Jtu = evaluate(JsuF, vcat(t, u, p, β) => vcat(S[j], U[:, j], P, B))
+            if typeof(JsuF) == Matrix{Expression}
+                Jtu = evaluate(JsuF, vcat(t, u, p) => vcat(S[j], U[:, j], P)) 
+            else
+                Jtu = JsuF
+            end
             sols = zeros(ComplexF64, k, k)
             for a in 1:k, b in 1:k
                 rhs = vcat([A[j, i, a, b] for i = 1:length(F_on_line)]...)

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -79,31 +79,10 @@ function track_pws_to_lines!(
     n = ambient_dim(PWS)
     for (j, bj) in enumerate(eachcol(directions))
         GC.Ks[j] = lifted_line(point, bj, n)
-    end
-
-    for (j, K) in enumerate(GC.Ks)
-        target_parameters!(GC.tracker, K)
+        target_parameters!(GC.tracker, GC.Ks[j])
         for (l, w) in enumerate(PWS.W)
             track!(GC.tracker, w, 1)
             GC.line_hypersurface_intersections[j][l] .= solution(GC.tracker)
         end
     end
-end
-
-function track_pws_to_line!(
-    GC,
-    point::AbstractVector,
-    single_direction::AbstractVector,
-    PWS::PseudoWitnessSet,
-)
-    n = ambient_dim(PWS)
-    GC.Ks = [lifted_line(point, single_direction, n)]
-
-    target_parameters!(GC.tracker, GC.Ks[1])
-    for (l, w) in enumerate(PWS.W)
-        track!(GC.tracker, w, 1)
-        GC.line_hypersurface_intersections[l] .= solution(GC.tracker)
-    end
-
-    
 end

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -89,3 +89,21 @@ function track_pws_to_lines!(
         end
     end
 end
+
+function track_pws_to_line!(
+    GC,
+    point::AbstractVector,
+    single_direction::AbstractVector,
+    PWS::PseudoWitnessSet,
+)
+    n = ambient_dim(PWS)
+    GC.Ks = [lifted_line(point, single_direction, n)]
+
+    target_parameters!(GC.tracker, GC.Ks[1])
+    for (l, w) in enumerate(PWS.W)
+        track!(GC.tracker, w, 1)
+        GC.line_hypersurface_intersections[l] .= solution(GC.tracker)
+    end
+
+    
+end


### PR DESCRIPTION
Added caching to the single slice method. Also slightly modified the GradientCache constructor to suit the single slice method. Modified the track_pws_to_lines! function to remove the implicit assumption that we always want to track k lines. 

The performance of the single slice method as compared to our other two methods can be seen on several examples in the file single_slice_test.jl. 