### PR TITLE
Ignore failed paths in single-slice method

### DIFF
--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -110,7 +110,7 @@ function track_pws_to_line!(
     for (l, w) in enumerate(PWS.W)
         track!(GC.tracker, w, 1)
         GC.line_hypersurface_intersections[1][l] .= solution(GC.tracker)
-        GC.track_report[l] = all(!isnan, GC.line_hypersurface_intersections[1][l]) # note if the track was successful or not
+        GC.track_report[l] = all(isfinite, GC.line_hypersurface_intersections[1][l]) # note if the track was successful or not
         if GC.track_report[l] == false
             @warn "Track $l failed. This point will be ignored in gradient and Hessian computations."
         end

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -110,5 +110,9 @@ function track_pws_to_line!(
     for (l, w) in enumerate(PWS.W)
         track!(GC.tracker, w, 1)
         GC.line_hypersurface_intersections[1][l] .= solution(GC.tracker)
+        GC.track_report[l] = all(!isnan, GC.line_hypersurface_intersections[1][l]) # note if the track was successful or not
+        if GC.track_report[l] == false
+            @warn "Track $l failed. This point will be ignored in gradient and Hessian computations."
+        end
     end
 end

--- a/src/slice_gradient_hessian.jl
+++ b/src/slice_gradient_hessian.jl
@@ -2,6 +2,7 @@ mutable struct GradientCache
     Ks::Vector{LinearSubspace}
     line_hypersurface_intersections::Vector
     tracker::EndgameTracker
+    track_report::Vector{Bool}
     JsuF::Vector{HC.CompiledSystem}
     JPF::Vector{HC.CompiledSystem}
     JBF::Vector{HC.CompiledSystem}
@@ -110,8 +111,9 @@ function GradientCache(PWS, B)
     JxB_temp = zeros(ComplexF64, N, size(JxB)...) # size(JxB)
     JxP_temp = zeros(ComplexF64, N, size(JxP)...)
     JPB_temp = zeros(ComplexF64, N, size(JPB)...)
+    track_report = zeros(Bool, d) # for keeping track of which paths are successful
 
-    GradientCache(Ks, line_hypersurface_intersections, tracker,
+    GradientCache(Ks, line_hypersurface_intersections, tracker, track_report,
                     JsuF,
                     JPF,
                     JBF,

--- a/src/slice_system.jl
+++ b/src/slice_system.jl
@@ -165,7 +165,7 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
 
     PWS, GC, B, ∇logqe, Hlogqe = r.PWS, r.GC, r.B, r.∇logqe, r.Hlogqe
 
-    u = fill!(u, 0.0 + 0.0im)
+    fill!(u, 0.0 + 0.0im)
 
     # Use cached symbolic objects and arrays
     JsuF = GC.JsuF

--- a/src/slice_system.jl
+++ b/src/slice_system.jl
@@ -90,7 +90,7 @@ function evaluate!(u, r::RoutingGradient, x, p = nothing)
     track_pws_to_line!(GC, x, B[:,1], PWS)
   
     for (j, sol) in enumerate(GC.line_hypersurface_intersections[1])
-        !GC.track_report[j] && continue # skip j-th track failed
+        !GC.track_report[j] && continue # skip if j-th track failed
         @assert all(!isnan, sol) "NaN entries in intersection points: $sol"
         for idx in 1:k
             X[idx] = sol[idx]
@@ -103,7 +103,7 @@ function evaluate!(u, r::RoutingGradient, x, p = nothing)
 
     #Obtain gradients of S and U with respect to p and β
     for i = 1:length(S)
-        !GC.track_report[i] && continue # skip i-th track failed
+        !GC.track_report[i] && continue # skip if i-th track failed
 
         v0 =  vcat(S[i], Uvals[:, i], x)
 
@@ -196,7 +196,7 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
 
 
     for (j, sol) in enumerate(GC.line_hypersurface_intersections[1])
-        !GC.track_report[j] && continue # skip j-th track failed
+        !GC.track_report[j] && continue # skip if j-th track failed
         for i in 1:k
             X[i] = sol[i]
         end
@@ -210,7 +210,7 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
     #Obtain gradients of S and U with respect to p and β
     for i = 1:length(S)
 
-        !GC.track_report[i] && continue # skip i-th track failed
+        !GC.track_report[i] && continue # skip if i-th track failed
 
         v0 =  vcat(S[i], Uvals[:, i], x)
         @assert all(!isnan, v0) "NaN entries in v0: $v0"
@@ -264,7 +264,7 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
     # Computation outlined in the abstract description Jon gave in Overleaf file
     for j = 1:length(S)
 
-        !GC.track_report[j] && continue # skip j-th track failed
+        !GC.track_report[j] && continue # skip if j-th track failed
 
         v0 =  vcat(S[j], Uvals[:, j], x)
 
@@ -316,7 +316,7 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
     #Compute Hessian
     fill!(hess, 0.0 + 0.0im)
     for j = 1:length(S)
-        !GC.track_report[j] && continue # skip j-th track failed
+        !GC.track_report[j] && continue # skip if j-th track failed
         Jtu = GC.Jtu_temp
         for (idx, J) in enumerate(JsuF)
             evaluate!(view(Jtu, :, idx), J, vcat(S[j], Uvals[:, j], x))

--- a/src/slice_system.jl
+++ b/src/slice_system.jl
@@ -70,8 +70,9 @@ import HomotopyContinuation.taylor!
 
 function evaluate!(u, r::RoutingGradient, x, p = nothing)
     PWS, GC, B, ∇logqe  = r.PWS, r.GC, r.B, r.∇logqe
-    
 
+    fill!(u, 0.0 + 0.0im)
+    
     # Use cached symbolic objects and arrays
     JsuF = GC.JsuF
     JPF = GC.JPF
@@ -89,6 +90,8 @@ function evaluate!(u, r::RoutingGradient, x, p = nothing)
     track_pws_to_line!(GC, x, B[:,1], PWS)
   
     for (j, sol) in enumerate(GC.line_hypersurface_intersections[1])
+        !GC.track_report[j] && continue # skip j-th track failed
+        @assert all(!isnan, sol) "NaN entries in intersection points: $sol"
         for idx in 1:k
             X[idx] = sol[idx]
         end
@@ -100,6 +103,7 @@ function evaluate!(u, r::RoutingGradient, x, p = nothing)
 
     #Obtain gradients of S and U with respect to p and β
     for i = 1:length(S)
+        !GC.track_report[i] && continue # skip i-th track failed
 
         v0 =  vcat(S[i], Uvals[:, i], x)
 
@@ -132,10 +136,11 @@ function evaluate!(u, r::RoutingGradient, x, p = nothing)
         LinearAlgebra.ldiv!(Jsu0, rhs1)
         
         SB[i,:] = rhs1[1, k+1:end]
+        u .-= SB[i,:]
     end
 
 
-    u .= -sum(eachrow(SB)) - ∇logqe(x)
+    u .-= ∇logqe(x)
     if !isnothing(p)
         u .-= p
     end
@@ -159,7 +164,8 @@ end
 function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
 
     PWS, GC, B, ∇logqe, Hlogqe = r.PWS, r.GC, r.B, r.∇logqe, r.Hlogqe
-    
+
+    u = fill!(u, 0.0 + 0.0im)
 
     # Use cached symbolic objects and arrays
     JsuF = GC.JsuF
@@ -190,6 +196,7 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
 
 
     for (j, sol) in enumerate(GC.line_hypersurface_intersections[1])
+        !GC.track_report[j] && continue # skip j-th track failed
         for i in 1:k
             X[i] = sol[i]
         end
@@ -203,7 +210,10 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
     #Obtain gradients of S and U with respect to p and β
     for i = 1:length(S)
 
+        !GC.track_report[i] && continue # skip i-th track failed
+
         v0 =  vcat(S[i], Uvals[:, i], x)
+        @assert all(!isnan, v0) "NaN entries in v0: $v0"
        
         JsuF_temp = GC.JsuF_temp
         for (idx, J) in enumerate(JsuF)
@@ -214,6 +224,8 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
         for (idx, J) in enumerate(JPF)
             evaluate!(view(JPF_temp, :, idx), J, v0)
         end
+
+
 
         JBF_temp = GC.JBF_temp
         for (idx, J) in enumerate(JBF)
@@ -238,15 +250,21 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
 
         UP[i,:,:] = rhs1[2:end, 1:k]
         UB[i,:,:] = rhs1[2:end, k+1:end]
+
+        u .-= SB[i,:]
+
     end
 
-    u .= -sum(eachrow(SB)) - ∇logqe(x)
+
+    u .-= ∇logqe(x)
     if !isnothing(p)
         u .-= p
     end
 
     # Computation outlined in the abstract description Jon gave in Overleaf file
     for j = 1:length(S)
+
+        !GC.track_report[j] && continue # skip j-th track failed
 
         v0 =  vcat(S[j], Uvals[:, j], x)
 
@@ -298,6 +316,7 @@ function evaluate_and_jacobian!(u, U, r::RoutingGradient, x, p = nothing)
     #Compute Hessian
     fill!(hess, 0.0 + 0.0im)
     for j = 1:length(S)
+        !GC.track_report[j] && continue # skip j-th track failed
         Jtu = GC.Jtu_temp
         for (idx, J) in enumerate(JsuF)
             evaluate!(view(Jtu, :, idx), J, vcat(S[j], Uvals[:, j], x))


### PR DESCRIPTION
Sometimes the path tracking in `track_pws_to_line!` fails (not entirely sure why), which causes NaN entries in `GC.line_hypersurface_intersections`, which makes `evaluate_and_jacobian!` crash. As discussed over email, it would be good if we could get around this, and one suggestion is to simply ignore the failed paths. 

Based on this, I've made the following changes:

* In `track_pws_to_line!`, we now check whether the tracking is successful or whether NaN entries have been introduced. The result of this check is stored in a boolean vector GC.track_report of length `d` (where `d` is the degree of the hypersurface). 

* In all steps where we loop through the d intersection points, we now skip the failed points. 

Testing that has been done (but would be great if somebody could double-check!):

* The code still runs as before for the quadratic and cubic example, and gives the same figures.
* I've run the 3RPR example for 10 minutes without any errors occurring.