### PR TITLE
Make monodromy results reusable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ julia> ∇r = RoutingGradient(F, [a, b]);
 We find the critical points via the `critical_points` function (the exact output depends on the randomized choice of center point `c` that happens when the routing function is created):
 
 ```julia-repl   
-julia> pts = critical_points(∇r) |> real_solutions
+julia> res, mon_res = critical_points(∇r);
+julia> routing_points = real_solutions(res);
 4-element Vector{Vector{Float64}}:
  [-5.175022390506237, -7.4163002433454395]
  [2.7890571286291124, 7.76755857260763]
@@ -64,7 +65,7 @@ julia> pts = critical_points(∇r) |> real_solutions
 Finally, we connect the critical points that belong to the same component of the complement:
 
 ```julia-repl
-julia> G, idx, failed_info = partition_of_critical_points(∇r, pts);
+julia> G, idx, failed_info = partition_of_critical_points(∇r, routing_points);
 ```
 
 The first output `G` describes the connected components. We see that the first, third and fourth critical points belong to the same connected component, and that the second one belongs to its own component:

--- a/examples/allee.jl
+++ b/examples/allee.jl
@@ -21,64 +21,9 @@ F = System([steady_state; x[1]*x[2]*x[3]*detJac], variables = [a; b; x])
 r = RoutingGradient(F, [a,b]);
 d = degree(r.PWS) 
 
-### Homotopy
-k = size(r, 2) # number of variables
-p1 = zeros(k)
-q1 = randn(k)
-H = RoutingPointsHomotopy(r, p1, q1)
-
-### Solve system using monodromy
-
-# Set up monodromy solver
-egtracker = EndgameTracker(H) # we want to add options later 
-trackers = [egtracker]
-x₀ = zeros(ComplexF64, size(H, k))
-unique_points = UniquePoints(
-    x₀,
-    1;
-)
-trace = zeros(ComplexF64, length(x₀) + 1, 3)
-P = Vector{ComplexF64}
-options = MonodromyOptions(
-    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
-    max_loops_no_progress = 10 # change the stopping criterion
-)
-
-MS = HomotopyContinuation.MonodromySolver(
-    trackers,
-    HomotopyContinuation.MonodromyLoop{P}[],
-    unique_points,
-    ReentrantLock(),
-    options,
-    HomotopyContinuation.MonodromyStatistics(),
-    trace,
-    ReentrantLock(),
-)
-
-# Start pair
-s0 = randn(ComplexF64, k)
-p0 = evaluate(r, s0)
-
-# Solve r = p0
-seed = rand(UInt32)
-mon_result = monodromy_solve(
-    MS,
-    s0,
-    p0,
-    seed
-)
-
-# Trace to solution of r = 0
-intermediate_p = randn(ComplexF64, length(p0))
-start_parameters!(H, p0)
-target_parameters!(H, intermediate_p)
-result_intermediate = HomotopyContinuation.solve(H, solutions(mon_result))
-start_parameters!(H, intermediate_p)
-target_parameters!(H, zeros(ComplexF64, length(p0)))
-result = HomotopyContinuation.solve(H, result_intermediate)
-
-# Extract the real solutions
-pts = real_solutions(result)
+### Routing points
+res, mon_res = critical_points(r)
+pts = real_solutions(res)
 
 ### Connected components
 G, idx, failed_info = partition_of_critical_points(r, pts)

--- a/examples/cubic_three_parameters.jl
+++ b/examples/cubic_three_parameters.jl
@@ -21,7 +21,7 @@ c = 10 .* randn(k)
 r = RoutingGradient(F, projection_variables; c=c)
 
 # critical points
-res = critical_points(r) # should be 22
+res, mon_res = critical_points(r) # should be 22
 pts = real_solutions(res)
 
 ### connecting 

--- a/examples/cubic_two_parameters.jl
+++ b/examples/cubic_two_parameters.jl
@@ -26,7 +26,7 @@ options = MonodromyOptions(
     max_loops_no_progress = 10 # change the stopping criterion
 )
 
-res0 = critical_points(r, options = options)
+res0, mon_res = critical_points(r, options = options)
 pts = real_solutions(res0)
 
 # Connecting 
@@ -54,14 +54,16 @@ contour(
 )
 
 
-implicit_plot!(
+implicit_plot(
     h; 
     xlims = (-M_x, M_x),
     ylims = (-M_y, M_y),
     linecolor = :black,
     linewidth = 6,
-    label = "discriminant"
+    label = "discriminant",
+	legend = false
 )
+savefig("./figures/cubic_discriminant.png")
 
 
 ## plot flow
@@ -99,7 +101,7 @@ for (i, component) in enumerate(G)
     scatter!(Tuple.(pts[component]), markercolor = palette[i], markersize = 8, label = "Critical points in region $i")
 end
 
-plot!(; legend = :bottomright, dpi=400, legendfontsize=6)
+plot!(; legend = false, dpi=400, legendfontsize=6, yticks=false, xticks=false)
 
-savefig("./figures/example_cubic.svg")
+savefig("./figures/example_cubic_without_legend.svg")
 savefig("./figures/example_cubic.png")

--- a/examples/four_bus.jl
+++ b/examples/four_bus.jl
@@ -78,5 +78,5 @@ p0 = evaluate(r, s0) #This returns a vector of NaNs. Upon further inspection,
                      #Note that this is still happening after making the change of restricting to non-singular solutions in the witness set.
 
 ### Monodromy 
-res = critical_points(r)
+res, mon_res = critical_points(r)
 pts = real_solutions(res)

--- a/examples/kuramoto.jl
+++ b/examples/kuramoto.jl
@@ -26,13 +26,34 @@ C = rand(2)
 d = degree(∇r.PWS)
 
 ### Critical points
-res = critical_points(∇r)
+
+# Find the complex critical points with monodromy
+options = MonodromyOptions(
+    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
+    max_loops_no_progress = 10 # change the stopping criterion
+)
+
+res, mon_res = critical_points(∇r, options = options)
+write_parameters("kuramoto_monodromy_parameters.txt", parameters(mon_res))
+write_solutions("kuramoto_monodromy_result.txt", solutions(mon_res)) 
+write_solutions("kuramoto_result.txt", solutions(res))
+
+# Try another round of monodromy (only if you think the first attempt missed solutions)
+res, mon_res = critical_points(∇r, solutions(mon_res), parameters(mon_res), options = options)
+write_parameters("kuramoto_monodromy_parameters.txt", parameters(mon_res))
+write_solutions("kuramoto_monodromy_result.txt", solutions(mon_res)) 
+write_solutions("kuramoto_result.txt", solutions(res))
+
+# Extract the real critical points
 pts = real_solutions(res)
+write_solutions("kuramoto_routing_points.txt", pts)
 
 ### Connected components
 G, idx, failed_info = partition_of_critical_points(∇r, pts)
+write_solutions("kuramoto_components.txt", G)
+write_parameters("kuramoto_components.txt", Int.(idx))
 
-### Plotting 
+### Plotting
 M_x = maximum(p -> abs(p[1]), pts) + 6
 M_y = maximum(p -> abs(p[2]), pts) + 6
 

--- a/examples/quadratic.jl
+++ b/examples/quadratic.jl
@@ -35,6 +35,9 @@ options = MonodromyOptions(
 # Find the complex critical points 
 res0, mon_res = critical_points(r, options = options)
 
+# Try another round of monodromy (only if you think the first attempt missed solutions)
+res0, mon_res = critical_points(r, solutions(mon_res), parameters(mon_res), options = options)
+
 # Restrict to the real critical points
 pts = real_solutions(res0)
 

--- a/examples/quadratic.jl
+++ b/examples/quadratic.jl
@@ -33,7 +33,7 @@ options = MonodromyOptions(
 )
 
 # Find the complex critical points 
-res0 = critical_points(r, options = options)
+res0, mon_res = critical_points(r, options = options)
 
 # Restrict to the real critical points
 pts = real_solutions(res0)

--- a/examples/spinodal.jl
+++ b/examples/spinodal.jl
@@ -34,65 +34,9 @@ r = RoutingGradient(F, ε)
 # This gives 6 but I know the discriminant has degree 72
 d = degree(r.PWS) 
 
-# Critical points
-
-### Homotopy
-k = size(r, 2) # number of variables
-p1 = zeros(k)
-q1 = randn(k)
-H = RoutingPointsHomotopy(r, p1, q1)
-
-### Use monodromy to solve ∇r = p0 for generic RHS
-egtracker = EndgameTracker(H) # we want to add options later 
-trackers = [egtracker]
-x₀ = zeros(ComplexF64, size(H, k))
-unique_points = UniquePoints(
-    x₀,
-    1;
-)
-trace = zeros(ComplexF64, length(x₀) + 1, 3)
-P = Vector{ComplexF64}
-options = MonodromyOptions(
-    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
-    max_loops_no_progress = 10 # change the stopping criterion
-)
-
-
-MS = HomotopyContinuation.MonodromySolver(
-    trackers,
-    HomotopyContinuation.MonodromyLoop{P}[],
-    unique_points,
-    ReentrantLock(),
-    options,
-    HomotopyContinuation.MonodromyStatistics(),
-    trace,
-    ReentrantLock(),
-)
-
-### start pair
-s0 = randn(ComplexF64, k)
-p0 = evaluate(r, s0)
-
-### monodromy 
-seed = rand(UInt32)
-mon_result = monodromy_solve(
-    MS,
-    s0,
-    p0,
-    seed
-)
-
-### move to parameter = 0
-intermediate_p = randn(ComplexF64, length(p0))
-start_parameters!(H, p0)
-target_parameters!(H, intermediate_p)
-result_intermediate = HomotopyContinuation.solve(H, solutions(mon_result))
-start_parameters!(H, intermediate_p)
-target_parameters!(H, zeros(ComplexF64, length(p0)))
-result = HomotopyContinuation.solve(H, result_intermediate)
-
-# Extract the real solutions
-pts = real_solutions(result)
+# Routing points
+res, mon_res = critical_points(r)
+pts = real_solutions(res)
 
 # Connected components
 G, idx, failed_info = partition_of_critical_points(r, pts)

--- a/examples/three_RPR.jl
+++ b/examples/three_RPR.jl
@@ -36,7 +36,8 @@ options = MonodromyOptions(
     parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
     max_loops_no_progress = 10 # change the stopping criterion
 )
-res = critical_points(r, options = options)
+
+res, mon_res = critical_points(r, options = options)
 pts = real_solutions(res)
 
 # connecting 

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -89,7 +89,9 @@ function ModelKit.taylor!(u, v::Val, H::RoutingPointsHomotopy, tx, t)
 end
 
 import HomotopyContinuation: MonodromyOptions, UniquePoints, EndgameTracker
-function critical_points(r::RoutingGradient; 
+function critical_points(r::RoutingGradient,
+                            S0::Union{AbstractVector{<:AbstractVector{<:Number}}, Nothing} = nothing,
+                            p0::Union{AbstractVector{<:Number}, Nothing} = nothing;
                             options = MonodromyOptions(parameter_sampler = p -> 10 .* randn(ComplexF64, length(p))),  
                             seed = rand(UInt32))
     k = size(r, 2) # number of variables
@@ -121,15 +123,18 @@ function critical_points(r::RoutingGradient;
     )
 
     #### set up start pair
-    s0 = randn(ComplexF64, k)
-    p0 = evaluate(r, s0)
+    if isnothing(p0) || isnothing(S0)
+        s0 = randn(ComplexF64, k)
+        p0 = evaluate(r, s0)
+        S0 = [s0]
+    end
 
     ### Monodromy 
     mon_result = monodromy_solve(
         MS,
-        s0,
+        S0,
         p0,
-        seed;
+        rand(UInt32);
     )
 
     ### move to parameter = 0

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -141,5 +141,5 @@ function critical_points(r::RoutingGradient;
     target_parameters!(H, zeros(ComplexF64, length(p0)))
     result = HomotopyContinuation.solve(H, result_intermediate)
 
-    result
+    result, mon_result
 end


### PR DESCRIPTION
As brought up in #11, it might happen that we want to further analyze the result from the monodromy step or reuse it for another round of monodromy. 

To this end, I suggest two modifications of `critical_points`:
* Make the choice of parameters `p0` and a vector of start solutions `S0` an optional input.
* Include the monodromy result `mon_res` as an output.

I've updated the main examples accordingly, and added an example for how this can be used in `quadratic.jl`.