### PR TITLE
Extra start solutions from gradient flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ julia> ∇r = RoutingGradient(F, [a, b]);
 We find the critical points via the `critical_points` function (the exact output depends on the randomized choice of center point `c` that happens when the routing function is created):
 
 ```julia-repl   
-julia> res, mon_res = critical_points(∇r);
-julia> routing_points = real_solutions(res);
+julia> routing_points, res, mon_res = critical_points(∇r);
+julia> routing_points
 4-element Vector{Vector{Float64}}:
  [-5.175022390506237, -7.4163002433454395]
  [2.7890571286291124, 7.76755857260763]

--- a/examples/3RPRv0.jl
+++ b/examples/3RPRv0.jl
@@ -42,8 +42,7 @@ options = MonodromyOptions(
     parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
-res, mon_res = critical_points(∇r, options = options)
-pts = real_solutions(res)
+pts, res, mon_res = critical_points(∇r, options = options)
 
 write_parameters("./results/3RPRv0/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/3RPRv0/monodromy_result.txt", solutions(mon_res)) 

--- a/examples/3RPRv0.jl
+++ b/examples/3RPRv0.jl
@@ -10,7 +10,7 @@ mkpath("./results/3RPRv0")
 
 Random.seed!(12345)
 
-time_start = time()
+time_start_round1 = time()
 
 # Set up incidence variety of the discriminant
 a2 = 14//10; a3 = 7//10; b3 = 1; A2 = 16//10; A3 = 9//10; B3 = 6//10; c3 = 1;
@@ -39,7 +39,7 @@ println("Degree of discriminant: $d")
 
 # Routing points
 options = MonodromyOptions(
-    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
+    parameter_sampler = p -> 100 .* randn(ComplexF64, length(p)), # bigger loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
 pts, res, mon_res = critical_points(∇r, options = options)
@@ -53,8 +53,8 @@ write_solutions("./results/3RPRv0/routing_points.txt", pts)
 G, idx, failed_info = partition_of_critical_points(∇r, pts)
 write("./results/3RPRv0/connected_components.txt", string(G))
 
-t_end = time()
-println("Computation time: $(t_end - time_start) seconds")
+time_end_round1 = time()
+println("Computation time for round 1: $(time_end_round1 - time_start_round1) seconds")
 
 # Analyze root counts
 S = System(f, variables = vcat(p,φ), parameters = projection_variables)
@@ -156,17 +156,27 @@ savefig("./figures/3RPR_zoomed_in.png")
 
 # Try another round of monodromy (only if you think the first attempt missed solutions)
 println("Running second round of monodromy...")
+time_start_round2 = time()
 old_number_of_monodromy_solutions = length(solutions(mon_res))
 options = MonodromyOptions(
-    parameter_sampler = p -> 100 .* randn(ComplexF64, length(p)), # bigger loops
+    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # smaller loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
-res, mon_res = critical_points(∇r, solutions(mon_res), parameters(mon_res), options = options)
+pts, res, mon_res = critical_points(∇r, solutions(mon_res), parameters(mon_res), options = options)
 if length(solutions(mon_res)) > old_number_of_monodromy_solutions
     println("Found new solutions with additional monodromy round!")
+    write_parameters("./results/3RPRv0/monodromy_parameters.txt", parameters(mon_res))
+    write_solutions("./results/3RPRv0/monodromy_result.txt", solutions(mon_res)) 
+    write_solutions("./results/3RPRv0/result.txt", solutions(res))
+    write_solutions("./results/3RPRv0/routing_points.txt", pts)
+    G, idx, failed_info = partition_of_critical_points(∇r, pts)
+    write("./results/3RPRv0/connected_components.txt", string(G))
 else
     println("No new solutions found in the additional monodromy round.")
 end
+
+time_round2 = time()
+println("Additional computation time for round 2: $(time_round2 - time_start_round2) seconds")
 
 # If new solutions were found, repeat the steps above manually!
 

--- a/examples/allee.jl
+++ b/examples/allee.jl
@@ -32,8 +32,7 @@ options = MonodromyOptions(
     parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
-res, mon_res = critical_points(∇r, options = options)
-pts = real_solutions(res)
+pts, res, mon_res = critical_points(∇r, options = options)
 
 write_parameters("./results/allee/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/allee/monodromy_result.txt", solutions(mon_res)) 

--- a/examples/allee.jl
+++ b/examples/allee.jl
@@ -1,5 +1,6 @@
 # Ecological system from https://www.worldscientific.com/doi/abs/10.1142/S0218127421502023
 # See also https://www.biorxiv.org/content/10.1101/2021.02.03.429609v2.full
+# More recent paper: https://arxiv.org/pdf/2501.19062
 
 using Pkg, Random
 Pkg.activate(".")
@@ -8,7 +9,7 @@ mkpath("./results/allee")
 
 Random.seed!(12345)
 
-t_start = time()
+t_start_round1 = time()
 
 # Set up incidence variety of discriminant
 @var a b x[1:3]
@@ -29,7 +30,7 @@ d = degree(∇r.PWS)
 
 # Routing points
 options = MonodromyOptions(
-    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
+    parameter_sampler = p -> 100 .* randn(ComplexF64, length(p)), # bigger loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
 pts, res, mon_res = critical_points(∇r, options = options)
@@ -43,8 +44,8 @@ write_solutions("./results/allee/routing_points.txt", pts)
 G, idx, failed_info = partition_of_critical_points(∇r, pts)
 write("./results/allee/connected_components.txt", string(G))
 
-t_end = time()
-println("Computation time: $(t_end - t_start) seconds")
+t_end_round1 = time()
+println("Computation time for round 1: $(t_end_round1 - t_start_round1) seconds")
 
 # Analyze root counts
 SS = System(steady_state, variables = x, parameters = [a; b])
@@ -60,18 +61,113 @@ for (i, comp) in enumerate(G)
     println("Positive root counts: $(positive_root_counts)\n")
 end
 
+# Plot result
+# Plotting
+M_x_max = maximum(p -> p[1], pts)*1.2
+M_x_min = minimum(p -> p[1], pts)*1.2
+M_y_max = maximum(p -> p[2], pts)*1.2
+M_y_min = minimum(p -> p[2], pts)*1.2
+
+# Guess of the discriminant (based on https://arxiv.org/pdf/2501.19062)
+h(x, y) = (-1//2*a^2*b^12 - 475//8*a^2*b^6 + 27//4*a*b^8 + 339//2*a^3*b^4 - 45//8*a*b^9 + 287//4*a^2*b^7 + 51//16*a*b^10 - 475//8*a^2*b^8 - 9//8*a*b^11 + 265//8*a^2*b^9 + 3//16*a*b^12 - 97//8*a^2*b^10 + 339//2*a^3*b^8 - 1//2*a^2*b^2 + 4*a^4 + 856*a^6 + 34992*a^9 - 3888*a^8 - 2592*a^7 - 96*a^5 - 1//64*b^12 + 3//32*b^11 - 15//64*b^10 + 5//16*b^9 - 15//64*b^8 + 3//32*b^7 - 1//64*b^6 - 9//8*a*b^5 + 3//16*a*b^4 - 69*a^4*b^2 - 570*a^5*b^3 + 1086*a^4*b^5 - 258*a^5*b^2 - 852*a^4*b^4 + 396*a^4*b^7 - 97//8*a^2*b^4 - 60*a^3*b^9 + 3*a^2*b^11 + 3246*a^6*b^2 + 984*a^5*b^4 - 852*a^4*b^6 - 2568*a^6*b + 5184*a^7*b^3 - 2568*a^6*b^5 + 384*a^5*b^7 - 20*a^4*b^9 - 7776*a^7*b^2 + 3246*a^6*b^4 - 258*a^5*b^6 - 69*a^4*b^8 + 12*a^3*b^10 + 5184*a^7*b - 2212*a^6*b^3 - 570*a^5*b^5 - 3888*a^8*b^2 - 2592*a^7*b^4 + 856*a^6*b^6 - 96*a^5*b^8 + 4*a^4*b^10 + 3888*a^8*b - 20*a^4*b - 60*a^3*b^3 + 12*a^3*b^2 + 3*a^2*b^3 + 384*a^5*b + 396*a^4*b^3 - 318*a^3*b^7 + 393*a^3*b^6 - 318*a^3*b^5 + 51//16*a*b^6 + 265//8*a^2*b^5 - 45//8*a*b^7)*(3*a + b)*(3*a - b + 1)*(b^2 + 3*a - b)*(4*a*b^4 - 36*a^2*b^2 - 8*a*b^3 - b^4 + 108*a^3 + 36*a^2*b + 12*a*b^2 + 2*b^3 - 36*a^2 - 8*a*b - b^2 + 4*a)^6*(b + 1)^6
+e = ∇r.e
+R(x, y) = log(abs(h(x,y) / (1 + (x-center[1])^2 + (y-center[2])^2)^e))
+
+for pt in pts
+    step_size = 1e-6
+    step_direction = rand(2)
+    step_direction = step_direction / norm(step_direction)
+    println( (R(pt...)-R((pt+step_direction*step_size)...))/step_size )
+end
+
+# contour(
+#     (M_x_min):0.01:M_x_max,
+#     (M_y_min):0.01:M_y_max,
+#     R,
+#     levels = 50,
+#     color = :plasma,
+#     clabels = false,
+#     cbar = false,
+#     lw = 1,
+#     fill = true,
+# )
+
+implicit_plot(
+    h; 
+    xlims = (M_x_min, M_x_max),
+    ylims = (M_y_min, M_y_max),
+    linecolor = :black,
+    linewidth = 2,
+    label = "discriminant",
+	legend = false,
+    resolution=3000
+)
+
+pts1 = pts[idx .!= 0]
+g(x, param, t) = real(evaluate(∇r, x))
+tspan = (0.0, 1e4)
+for u0 in pts1
+	jac = real(evaluate_and_jacobian(∇r, u0)[2])
+	eigen_data = LinearAlgebra.eigen(jac)
+	eigenvalues = eigen_data.values
+	eigenvectors = eigen_data.vectors
+	positive_directions = [i for (i, λ) in enumerate(eigenvalues) if real(λ) > 0]
+	j = first(positive_directions)
+	v = eigenvectors[:, j]
+
+	prob = ODEProblem(g, u0 + 0.01*v, tspan)
+	sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
+	flow = Tuple.(sol.u)
+	l = length(flow)
+	k = div(l, 3)
+	plot!(flow[1:k], linecolor = :steelblue, linewidth = 2, label = false, arrow = :closed)
+	plot!(flow[k:end], linecolor = :steelblue, linewidth = 2, label = false)
+	prob = ODEProblem(g, u0 - 0.01*v, tspan)
+	sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
+	flow = Tuple.(sol.u)
+	l = length(flow)
+	k = div(l, 3)
+	plot!(flow[1:k], linecolor = :steelblue, linewidth = 2, label = false, arrow = :closed)
+	plot!(flow[k:end], linecolor = :steelblue, linewidth = 2, label = false)
+end
+
+palette = collect(range(colorant"darkgreen", stop=colorant"lightgreen", length=length(G)));
+for (i, component) in enumerate(G)
+    scatter!(Tuple.(pts[component]), markercolor = palette[i], markersize = 3, label = "Critical points in region $i")
+end
+
+plot!(; legend = true, dpi=400, legendfontsize=6)
+
+savefig("./figures/allee.svg")
+savefig("./figures/allee.png")
+
+plot!(; xlims = (-1,M_x_max), ylims = (-1,M_y_max), legend=:topleft)
+
+savefig("./figures/allee.svg")
+savefig("./figures/allee.png")
+
 # Try another round of monodromy (only if you think the first attempt missed solutions)
 println("Running second round of monodromy...")
+t_start_round2 = time()
 old_number_of_monodromy_solutions = length(solutions(mon_res))
 options = MonodromyOptions(
-    parameter_sampler = p -> 100 .* randn(ComplexF64, length(p)), # bigger loops
+    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # smaller loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
-res, mon_res = critical_points(∇r, solutions(mon_res), parameters(mon_res), options = options)
+pts, res, mon_res = critical_points(∇r, solutions(mon_res), parameters(mon_res), options = options)
 if length(solutions(mon_res)) > old_number_of_monodromy_solutions
     println("Found new solutions with additional monodromy round!")
+    write_parameters("./results/allee/monodromy_parameters.txt", parameters(mon_res))
+    write_solutions("./results/allee/monodromy_result.txt", solutions(mon_res)) 
+    write_solutions("./results/allee/result.txt", solutions(res))
+    write_solutions("./results/allee/routing_points.txt", pts)
+    G, idx, failed_info = partition_of_critical_points(∇r, pts)
+    write("./results/allee/connected_components.txt", string(G))
 else
     println("No new solutions found in the additional monodromy round.")
 end
+
+t_end_round2 = time()
+println("Additional computation time for round 2: $(t_end_round2 - t_start_round2) seconds")
 
 # If new solutions were found, repeat the steps above manually!

--- a/examples/allee.jl
+++ b/examples/allee.jl
@@ -2,7 +2,7 @@
 # See also https://www.biorxiv.org/content/10.1101/2021.02.03.429609v2.full
 # More recent paper: https://arxiv.org/pdf/2501.19062
 
-using Pkg, Random
+using Pkg, Random, Plots, ImplicitPlots
 Pkg.activate(".")
 include("../src/functions.jl");
 mkpath("./results/allee")
@@ -34,6 +34,9 @@ options = MonodromyOptions(
     max_loops_no_progress = 15 # change the stopping criterion
 )
 pts, res, mon_res = critical_points(∇r, options = options)
+
+# pts = [[1.5008505041416076, -4.992054374172119], [8.873775251675713, 10.184539724387184], [21.352372122219965, 26.73062909286873], [-9.516787924356157, 32.510119627058735], [10.144425852538403, 35.413484056491725], [0.22748939289880724, -2.9163837667277086], [2.479841961837091, -1.2421350166611869], [-0.142094211295228, 0.490144149893062], [-0.5548476367836471, 1.6960880661969613], [2.4025298982729666, -0.4765324163490884], [0.07023920300282123, -0.8760732585762937], [0.22143827315231507, 4.821953936949241], [0.09692923712483603, 4.814679303770955], [0.27409106612436296, -0.8832016985602994], [0.09848416350011838, -2.9980288906885226], [0.035627837070082796, 0.39605675328604417], [0.01975229042725789, 0.49002885154919423], [0.07615249752961624, 0.39138790391723843], [0.07583668038353164, 0.4889420759562086], [0.0521892333980436, 0.23706051426698405], [0.07530216907621935, 0.6210485701172596], [0.11807542738005739, 1.8172629904397462], [0.03630757960677417, 0.5962043763951855], [0.054330283033610524, 0.7449326022366476]]
+
 
 write_parameters("./results/allee/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/allee/monodromy_result.txt", solutions(mon_res)) 
@@ -69,16 +72,10 @@ M_y_max = maximum(p -> p[2], pts)*1.2
 M_y_min = minimum(p -> p[2], pts)*1.2
 
 # Guess of the discriminant (based on https://arxiv.org/pdf/2501.19062)
-h(x, y) = (-1//2*a^2*b^12 - 475//8*a^2*b^6 + 27//4*a*b^8 + 339//2*a^3*b^4 - 45//8*a*b^9 + 287//4*a^2*b^7 + 51//16*a*b^10 - 475//8*a^2*b^8 - 9//8*a*b^11 + 265//8*a^2*b^9 + 3//16*a*b^12 - 97//8*a^2*b^10 + 339//2*a^3*b^8 - 1//2*a^2*b^2 + 4*a^4 + 856*a^6 + 34992*a^9 - 3888*a^8 - 2592*a^7 - 96*a^5 - 1//64*b^12 + 3//32*b^11 - 15//64*b^10 + 5//16*b^9 - 15//64*b^8 + 3//32*b^7 - 1//64*b^6 - 9//8*a*b^5 + 3//16*a*b^4 - 69*a^4*b^2 - 570*a^5*b^3 + 1086*a^4*b^5 - 258*a^5*b^2 - 852*a^4*b^4 + 396*a^4*b^7 - 97//8*a^2*b^4 - 60*a^3*b^9 + 3*a^2*b^11 + 3246*a^6*b^2 + 984*a^5*b^4 - 852*a^4*b^6 - 2568*a^6*b + 5184*a^7*b^3 - 2568*a^6*b^5 + 384*a^5*b^7 - 20*a^4*b^9 - 7776*a^7*b^2 + 3246*a^6*b^4 - 258*a^5*b^6 - 69*a^4*b^8 + 12*a^3*b^10 + 5184*a^7*b - 2212*a^6*b^3 - 570*a^5*b^5 - 3888*a^8*b^2 - 2592*a^7*b^4 + 856*a^6*b^6 - 96*a^5*b^8 + 4*a^4*b^10 + 3888*a^8*b - 20*a^4*b - 60*a^3*b^3 + 12*a^3*b^2 + 3*a^2*b^3 + 384*a^5*b + 396*a^4*b^3 - 318*a^3*b^7 + 393*a^3*b^6 - 318*a^3*b^5 + 51//16*a*b^6 + 265//8*a^2*b^5 - 45//8*a*b^7)*(3*a + b)*(3*a - b + 1)*(b^2 + 3*a - b)*(4*a*b^4 - 36*a^2*b^2 - 8*a*b^3 - b^4 + 108*a^3 + 36*a^2*b + 12*a*b^2 + 2*b^3 - 36*a^2 - 8*a*b - b^2 + 4*a)^6*(b + 1)^6
+h(a, b) = (-1/2*a^2*b^12 - 475/8*a^2*b^6 + 27/4*a*b^8 + 339/2*a^3*b^4 - 45/8*a*b^9 + 287/4*a^2*b^7 + 51/16*a*b^10 - 475/8*a^2*b^8 - 9/8*a*b^11 + 265/8*a^2*b^9 + 3/16*a*b^12 - 97/8*a^2*b^10 + 339/2*a^3*b^8 - 1/2*a^2*b^2 + 4*a^4 + 856*a^6 + 34992*a^9 - 3888*a^8 - 2592*a^7 - 96*a^5 - 1/64*b^12 + 3/32*b^11 - 15/64*b^10 + 5/16*b^9 - 15/64*b^8 + 3/32*b^7 - 1/64*b^6 - 9/8*a*b^5 + 3/16*a*b^4 - 69*a^4*b^2 - 570*a^5*b^3 + 1086*a^4*b^5 - 258*a^5*b^2 - 852*a^4*b^4 + 396*a^4*b^7 - 97/8*a^2*b^4 - 60*a^3*b^9 + 3*a^2*b^11 + 3246*a^6*b^2 + 984*a^5*b^4 - 852*a^4*b^6 - 2568*a^6*b + 5184*a^7*b^3 - 2568*a^6*b^5 + 384*a^5*b^7 - 20*a^4*b^9 - 7776*a^7*b^2 + 3246*a^6*b^4 - 258*a^5*b^6 - 69*a^4*b^8 + 12*a^3*b^10 + 5184*a^7*b - 2212*a^6*b^3 - 570*a^5*b^5 - 3888*a^8*b^2 - 2592*a^7*b^4 + 856*a^6*b^6 - 96*a^5*b^8 + 4*a^4*b^10 + 3888*a^8*b - 20*a^4*b - 60*a^3*b^3 + 12*a^3*b^2 + 3*a^2*b^3 + 384*a^5*b + 396*a^4*b^3 - 318*a^3*b^7 + 393*a^3*b^6 - 318*a^3*b^5 + 51/16*a*b^6 + 265/8*a^2*b^5 - 45/8*a*b^7)*(3*a + b)*(3*a - b + 1)*(b^2 + 3*a - b)*(4*a*b^4 - 36*a^2*b^2 - 8*a*b^3 - b^4 + 108*a^3 + 36*a^2*b + 12*a*b^2 + 2*b^3 - 36*a^2 - 8*a*b - b^2 + 4*a)*(b + 1)
 e = ∇r.e
 R(x, y) = log(abs(h(x,y) / (1 + (x-center[1])^2 + (y-center[2])^2)^e))
 
-for pt in pts
-    step_size = 1e-6
-    step_direction = rand(2)
-    step_direction = step_direction / norm(step_direction)
-    println( (R(pt...)-R((pt+step_direction*step_size)...))/step_size )
-end
 
 # contour(
 #     (M_x_min):0.01:M_x_max,
@@ -100,8 +97,14 @@ implicit_plot(
     linewidth = 2,
     label = "discriminant",
 	legend = false,
-    resolution=3000
+    resolution = 1000,
+    aspect_ratio = :auto,
 )
+
+palette = collect(range(colorant"darkgreen", stop=colorant"lightgreen", length=length(G)));
+for (i, component) in enumerate(G)
+    scatter!(Tuple.(pts[component]), markercolor = palette[i], markersize = 3, label = "Critical points in region $i")
+end
 
 pts1 = pts[idx .!= 0]
 g(x, param, t) = real(evaluate(∇r, x))
@@ -131,12 +134,8 @@ for u0 in pts1
 	plot!(flow[k:end], linecolor = :steelblue, linewidth = 2, label = false)
 end
 
-palette = collect(range(colorant"darkgreen", stop=colorant"lightgreen", length=length(G)));
-for (i, component) in enumerate(G)
-    scatter!(Tuple.(pts[component]), markercolor = palette[i], markersize = 3, label = "Critical points in region $i")
-end
 
-plot!(; legend = true, dpi=400, legendfontsize=6)
+plot!(; legend = false, dpi=400, legendfontsize=6)
 
 savefig("./figures/allee.svg")
 savefig("./figures/allee.png")

--- a/examples/cubic_three_parameters.jl
+++ b/examples/cubic_three_parameters.jl
@@ -21,8 +21,7 @@ c = 10 .* randn(k)
 r = RoutingGradient(F, projection_variables; c=c)
 
 # critical points
-res, mon_res = critical_points(r) # should be 22
-pts = real_solutions(res)
+pts, res, mon_res = critical_points(r)
 
 ### connecting 
 G, idx, failed_info = partition_of_critical_points(r, pts)

--- a/examples/cubic_two_parameters.jl
+++ b/examples/cubic_two_parameters.jl
@@ -39,7 +39,7 @@ M_y = maximum(p -> abs(p[2]), pts) + 6
 
 # Discriminant
 h(x, y) = 4*x^3 - x^2*y^2 - 18*x*y + 4*y^3 + 27
-e = degree(r.PWS)
+e = r.e
 R(x, y) = log(abs(h(x,y) / (1 + (x-c[1])^2 + (y-c[2])^2)^e))
 contour(
     (-M_x):0.1:M_x,

--- a/examples/cubic_two_parameters.jl
+++ b/examples/cubic_two_parameters.jl
@@ -53,7 +53,7 @@ contour(
 )
 
 
-implicit_plot(
+implicit_plot!(
     h; 
     xlims = (-M_x, M_x),
     ylims = (-M_y, M_y),
@@ -62,7 +62,6 @@ implicit_plot(
     label = "discriminant",
 	legend = false
 )
-savefig("./figures/cubic_discriminant.png")
 
 
 ## plot flow

--- a/examples/cubic_two_parameters.jl
+++ b/examples/cubic_two_parameters.jl
@@ -26,8 +26,7 @@ options = MonodromyOptions(
     max_loops_no_progress = 10 # change the stopping criterion
 )
 
-res0, mon_res = critical_points(r, options = options)
-pts = real_solutions(res0)
+pts, res0, mon_res = critical_points(r, options = options)
 
 # Connecting 
 G, idx, failed_info = partition_of_critical_points(r, pts)

--- a/examples/four_bus.jl
+++ b/examples/four_bus.jl
@@ -77,6 +77,5 @@ p0 = evaluate(r, s0) #This returns a vector of NaNs. Upon further inspection,
                      #track! is terminating with the code :terminated_invalid_startvalue_singular_jacobian
                      #Note that this is still happening after making the change of restricting to non-singular solutions in the witness set.
 
-### Monodromy 
-res, mon_res = critical_points(r)
-pts = real_solutions(res)
+### Routing points 
+pts, res, mon_res = critical_points(r)

--- a/examples/kuramoto.jl
+++ b/examples/kuramoto.jl
@@ -10,7 +10,7 @@ mkpath("./results/kuramoto");
 
 Random.seed!(12345)
 
-time_start = time()
+time_start_round1 = time()
 
 ### Set up incidence variety of discriminant
 @var s[1:2] c[1:2] w[1:2]
@@ -32,11 +32,16 @@ d = degree(∇r.PWS)
 
 ### Critical points
 options = MonodromyOptions(
-    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
+    parameter_sampler = p -> 100 .* randn(ComplexF64, length(p)), # bigger loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
 
 pts, res, mon_res = critical_points(∇r, options = options)
+
+#pts = [[0.5427601994434249, -0.18018901419984795], [0.29906700601796926, 0.28724870687091925], [0.2669354407861624, -0.4952522652667655], [1.145368151259418, 1.068728568956334], [-0.25368660955089023, -0.25993444125577186], [-0.17771441531166282,
+ 0.5387535784862593], [0.2008029731610833, 0.002860207071978377], [0.016686800070020488, 0.013086455729810365], [1.1459707810744657, -2.0227042242670263], [-2.08198783160287, 1.1941751108001044], [-0.4912245696789008, 0.26114806904662935], [0.5555285159325019, -0.04274587983033408], [-0.532050221848435, 0.5166632948556596], [-0.04527729807079262, 0.5550131169046842], [-0.5300592954204847, 0.002310013070133069], [0.0003170066357472208, -0.5294391189743498], [0.5167363916638344
+, -0.533021383996236], [-0.18123871915469447, 0.0012230475982083575], [-0.18169506427415155, 0.18694347178850332], [0.0018827845572204564, -0.18215938093965264]
+, [0.18842378915335004, -0.18322319106926327], [0.003463119599510463, 0.19915763200484898], [-3.2103350168862725, -3.2383120091836863]]
 
 write_parameters("./results/kuramoto/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/kuramoto/monodromy_result.txt", solutions(mon_res)) 
@@ -47,8 +52,8 @@ write_solutions("./results/kuramoto/routing_points.txt", pts)
 G, idx, failed_info = partition_of_critical_points(∇r, pts)
 write("./results/kuramoto/connected_components.txt", string(G))
 
-time_end = time()
-println("Computation time: $(time_end - time_start) seconds")
+time_end_round1 = time()
+println("Computation time for round 1: $(time_end_round1 - time_start_round1) seconds")
 
 ### Analyze root counts
 S = System(steady_state, variables = [s; c], parameters = w)
@@ -139,30 +144,41 @@ for (i, component) in enumerate(G)
     scatter!(Tuple.(pts[component]), markercolor = palette[i], markersize = 3, label = "Critical points in region $i")
 end
 
-plot!(; legend = true, dpi=400, legendfontsize=6)
-#plot!(; legend = false, dpi=400, legendfontsize=6, yticks=false, xticks=false)
+plot!(; legend=:outertopright, dpi=400, legendfontsize=6)
+#plot!(; legend = false, dpi=400, legendfontsize=6)
 
-savefig("./figures/kuramoto.svg")
-savefig("./figures/kuramoto.png")
+# savefig("./figures/kuramoto.svg")
+# savefig("./figures/kuramoto.png")
 
-plot!(; xlims = (-1, 1), ylims = (-1, 1))
+plot!(; xlims = (-0.8, 0.8), ylims = (-0.8, 0.8))
 
-savefig("./figures/kuramoto_zoomed_in.svg")
-savefig("./figures/kuramoto_zoomed_in.png")
+# savefig("./figures/kuramoto_zoomed_in.svg")
+# savefig("./figures/kuramoto_zoomed_in.png")
 
 
 # Try another round of monodromy (only if you think the first attempt missed solutions)
 println("Running second round of monodromy...")
+time_start_round2 = time()
 old_number_of_monodromy_solutions = length(solutions(mon_res))
 options = MonodromyOptions(
-    parameter_sampler = p -> 100 .* randn(ComplexF64, length(p)), # bigger loops
+    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # smaller loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
-res, mon_res = critical_points(∇r, solutions(mon_res), parameters(mon_res), options = options)
+pts, res, mon_res = critical_points(∇r, solutions(mon_res), parameters(mon_res), options = options)
 if length(solutions(mon_res)) > old_number_of_monodromy_solutions
     println("Found new solutions with additional monodromy round!")
+    write_parameters("./results/kuramoto/monodromy_parameters.txt", parameters(mon_res))
+    write_solutions("./results/kuramoto/monodromy_result.txt", solutions(mon_res)) 
+    write_solutions("./results/kuramoto/result.txt", solutions(res))
+    write_solutions("./results/kuramoto/routing_points.txt", pts)
+    G, idx, failed_info = partition_of_critical_points(∇r, pts)
+    write("./results/kuramoto/connected_components.txt", string(G))
 else
     println("No new solutions found in the additional monodromy round.")
 end
+
+time_end_round2 = time()
+println("Additional computation time for round 2: $(time_end_round2 - time_start_round2) seconds")
+
 
 # If new solutions were found, repeat the steps above manually!

--- a/examples/kuramoto.jl
+++ b/examples/kuramoto.jl
@@ -31,21 +31,16 @@ write_parameters("./results/kuramoto/center.txt", C)
 d = degree(∇r.PWS)
 
 ### Critical points
-
-# Find the complex critical points with monodromy
 options = MonodromyOptions(
     parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
     max_loops_no_progress = 15 # change the stopping criterion
 )
 
-res, mon_res = critical_points(∇r, options = options)
+pts, res, mon_res = critical_points(∇r, options = options)
 
 write_parameters("./results/kuramoto/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/kuramoto/monodromy_result.txt", solutions(mon_res)) 
 write_solutions("./results/kuramoto/result.txt", solutions(res))
-
-# Extract the real critical points
-pts = real_solutions(res)
 write_solutions("./results/kuramoto/routing_points.txt", pts)
 
 ### Connected components

--- a/examples/quadratic.jl
+++ b/examples/quadratic.jl
@@ -33,15 +33,12 @@ options = MonodromyOptions(
 )
 
 # Find the complex critical points 
-res0, mon_res = critical_points(r, options = options)
+pts, res0, mon_res = critical_points(r, num_gradient_flow_starts=0, verbose=true, options = options)
 
 # Try another round of monodromy (only if you think the first attempt missed solutions)
-res0, mon_res = critical_points(r, solutions(mon_res), parameters(mon_res), options = options)
+#pts, res0, mon_res = critical_points(r, solutions(mon_res), parameters(mon_res), options = options)
 
-# Restrict to the real critical points
-pts = real_solutions(res0)
-
-# Connect the crticial points
+# Connect the critical points
 G, idx, failed_info = partition_of_critical_points(r, pts)
 G
 

--- a/examples/quadratic.jl
+++ b/examples/quadratic.jl
@@ -33,7 +33,7 @@ options = MonodromyOptions(
 )
 
 # Find the complex critical points 
-pts, res0, mon_res = critical_points(r, num_gradient_flow_starts=0, verbose=true, options = options)
+pts, res0, mon_res = critical_points(r, options = options)
 
 # Try another round of monodromy (only if you think the first attempt missed solutions)
 #pts, res0, mon_res = critical_points(r, solutions(mon_res), parameters(mon_res), options = options)

--- a/examples/spinodal.jl
+++ b/examples/spinodal.jl
@@ -35,8 +35,7 @@ r = RoutingGradient(F, ε)
 d = degree(r.PWS) 
 
 # Routing points
-res, mon_res = critical_points(r)
-pts = real_solutions(res)
+pts, res, mon_res = critical_points(r)
 
 # Connected components
 G, idx, failed_info = partition_of_critical_points(r, pts)

--- a/examples/start_solutions_via_gradient_flow_example.jl
+++ b/examples/start_solutions_via_gradient_flow_example.jl
@@ -117,7 +117,7 @@ M_y = maximum(p -> abs(p[2]), pts) + 6
 
 # Discriminant
 h(x, y) = 4*x^3 - x^2*y^2 - 18*x*y + 4*y^3 + 27
-e = degree(r.PWS)
+e = r.e
 R(x, y) = log(abs(h(x,y) / (1 + (x-c[1])^2 + (y-c[2])^2)^e))
 contour(
     (-M_x):0.1:M_x,

--- a/examples/start_solutions_via_gradient_flow_example.jl
+++ b/examples/start_solutions_via_gradient_flow_example.jl
@@ -1,0 +1,182 @@
+using Pkg
+Pkg.activate(".")
+
+using ImplicitPlots, Plots, Random
+
+include("../src/functions.jl");
+
+Random.seed!(0x8b868320)
+
+########
+
+# The discriminant of x^3 + a * x^2 + b*x + 1 is
+# 4*a^3 - a^2*b^2 - 18*a*b + 4*b^3 + 27
+@var a b x
+F = System([x^3 + a * x^2 + b*x + 1; 3*x^2 + 2*a*x + b], variables = [a, b, x])
+
+projection_variables = [a; b]
+k = length(projection_variables)
+
+c = [13.758979284873828, -0.09884333335596635]
+r = RoutingGradient(F, projection_variables; c = c)
+
+# Set up homotopy and monodromy solver
+options = MonodromyOptions(
+    parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)), # bigger loops
+    max_loops_no_progress = 10 # change the stopping criterion
+)
+
+p1 = zeros(k)
+q1 = randn(k)
+H = RoutingPointsHomotopy(r, p1, q1)
+egtracker = EndgameTracker(H) # we want to add options later 
+trackers = [egtracker]
+x₀ = zeros(ComplexF64, size(H, k))
+unique_points = UniquePoints(
+	x₀,
+	1;
+)
+trace = zeros(ComplexF64, length(x₀) + 1, 3)
+P = Vector{ComplexF64}
+MS = HomotopyContinuation.MonodromySolver(
+	trackers,
+	HomotopyContinuation.MonodromyLoop{P}[],
+	unique_points,
+	ReentrantLock(),
+	options,
+	HomotopyContinuation.MonodromyStatistics(),
+	trace,
+	ReentrantLock(),
+)
+
+# Start pair
+s0 = randn(ComplexF64, k)
+p0 = evaluate(r, s0)
+S0 = [s0]
+
+##########################################
+
+num_gradient_flow_starts = 10
+
+# Find solutions of ∇r=0 through gradient descent
+# Then trace them back to solutions of ∇r=p0 and add them to S0
+new_pts = Vector{ComplexF64}[]
+g(x, param, t) = real(evaluate(r, x))
+tspan = (0.0, 1e4)
+
+println("Expanding the set of start solutions via gradient flow...")
+
+for _ in 1:num_gradient_flow_starts
+    start_point = randn(k)
+    v = randn(k); v = v / norm(v);
+    prob = ODEProblem(g, start_point+0.001*v, tspan)
+    sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
+    convergence_point = last(sol.u)
+    improved_point = newton(r, convergence_point) |> solution
+    push!(new_pts, improved_point)
+end
+new_pts = HC.unique_points(new_pts)
+
+println("Found $(length(new_pts)) routing points via gradient flow.")
+
+start_parameters!(H, zeros(ComplexF64, length(p0)));
+target_parameters!(H, p0);
+s0_new_sols = HC.solve(H, new_pts) |> solutions
+S0 = HC.unique_points([S0; s0_new_sols])
+
+println("Traced to $(length(S0)-1) additional start solutions for the monodromy.")
+
+##########################################
+
+# Now do the monodromy step
+mon_result = monodromy_solve(
+	MS,
+	S0,
+	p0,
+	rand(UInt32);
+)
+
+# Move back ∇r = 0
+intermediate_p = randn(ComplexF64, length(p0))
+start_parameters!(H, p0)
+target_parameters!(H, intermediate_p)
+result_intermediate = HomotopyContinuation.solve(H, solutions(mon_result))
+start_parameters!(H, intermediate_p)
+target_parameters!(H, zeros(ComplexF64, length(p0)))
+result = HomotopyContinuation.solve(H, result_intermediate)
+
+pts = real_solutions(result)
+
+# Connecting the routing points
+G, idx, failed_info = partition_of_critical_points(r, pts)
+G
+
+# Plotting 
+M_x = maximum(p -> abs(p[1]), pts) + 6
+M_y = maximum(p -> abs(p[2]), pts) + 6
+
+# Discriminant
+h(x, y) = 4*x^3 - x^2*y^2 - 18*x*y + 4*y^3 + 27
+e = degree(r.PWS)
+R(x, y) = log(abs(h(x,y) / (1 + (x-c[1])^2 + (y-c[2])^2)^e))
+contour(
+    (-M_x):0.1:M_x,
+    (-M_y):0.1:M_y,
+    R,
+    levels = 50,
+    color = :plasma,
+    clabels = false,
+    cbar = false,
+    lw = 1,
+    fill = true,
+)
+
+implicit_plot(
+    h; 
+    xlims = (-M_x, M_x),
+    ylims = (-M_y, M_y),
+    linecolor = :black,
+    linewidth = 6,
+    label = "discriminant",
+	legend = false
+)
+
+## plot flow
+pts1 = pts[idx .!= 0]
+g(x, param, t) = real(evaluate(r, x))
+tspan = (0.0, 1e4)
+for u0 in pts1
+	jac = real(evaluate_and_jacobian(r, u0)[2])
+	eigen_data = LinearAlgebra.eigen(jac)
+	eigenvalues = eigen_data.values
+	eigenvectors = eigen_data.vectors
+	positive_directions = [i for (i, λ) in enumerate(eigenvalues) if real(λ) > 0]
+	j = first(positive_directions)
+	v = eigenvectors[:, j]
+
+	prob = ODEProblem(g, u0 + 0.01*v, tspan)
+	sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
+	flow = Tuple.(sol.u)
+	l = length(flow)
+	k = div(l, 3)
+	plot!(flow[1:k], linecolor = :steelblue, linewidth = 3, label = false, arrow = true)
+	plot!(flow[k:end], linecolor = :steelblue, linewidth = 3, label = false)
+	prob = ODEProblem(g, u0 - 0.01*v, tspan)
+	sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
+	flow = Tuple.(sol.u)
+	l = length(flow)
+	k = div(l, 3)
+	plot!(flow[1:k], linecolor = :steelblue, linewidth = 3, label = false, arrow = true)
+	plot!(flow[k:end], linecolor = :steelblue, linewidth = 3, label = false)
+end
+
+## plot critical points
+palette = collect(range(colorant"darkgreen", stop=colorant"lightgreen", length=length(G)))
+for (i, component) in enumerate(G)
+    scatter!(Tuple.(pts[component]), markercolor = palette[i], markersize = 8, label = "Critical points in region $i")
+end
+
+plot!(; legend = false, dpi=400, legendfontsize=6, yticks=false, xticks=false)
+
+# savefig("./figures/example_cubic.png")
+# savefig("./figures/example_cubic.svg")

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -146,5 +146,6 @@ function critical_points(r::RoutingGradient,
     target_parameters!(H, zeros(ComplexF64, length(p0)))
     result = HomotopyContinuation.solve(H, result_intermediate)
 
-    result, mon_result
+    routing_points = real_solutions(result)
+    routing_points, result, mon_result
 end

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -160,9 +160,10 @@ function critical_points(r::RoutingGradient,
         if !monodromy_at_zero
             start_parameters!(H, zeros(ComplexF64, length(rhs0)));
             target_parameters!(H, rhs0);
-            s0_new_sols = HC.solve(H, new_pts) |> solutions
-            S0 = HC.unique_points([S0; s0_new_sols])
-            verbose && println("Traced to $(length(S0)-1) additional start solutions for the monodromy.")
+            S0_new_sols = HC.solve(H, new_pts) |> solutions
+            number_of_old_sols = length(S0)
+            S0 = HC.unique_points([S0; S0_new_sols])
+            verbose && println("Traced to $(length(S0)-number_of_old_sols) additional start solutions for the monodromy.")
         else
             S0 = [S0; new_pts]
         end

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -92,6 +92,8 @@ import HomotopyContinuation: MonodromyOptions, UniquePoints, EndgameTracker
 function critical_points(r::RoutingGradient,
                             S0::Union{AbstractVector{<:AbstractVector{<:Number}}, Nothing} = nothing,
                             p0::Union{AbstractVector{<:Number}, Nothing} = nothing;
+                            verbose = true,
+                            num_gradient_flow_starts = 100,
                             options = MonodromyOptions(parameter_sampler = p -> 10 .* randn(ComplexF64, length(p))),  
                             seed = rand(UInt32))
     k = size(r, 2) # number of variables
@@ -129,7 +131,32 @@ function critical_points(r::RoutingGradient,
         S0 = [s0]
     end
 
-    ### Monodromy 
+    ### Expand S0: find solutions of ∇r=0 through gradient descent and trace to ∇r=p0
+    new_pts = Vector{ComplexF64}[]
+    g(x, param, t) = real(evaluate(r, x))
+    tspan = (0.0, 1e4)
+
+    if num_gradient_flow_starts>0
+        verbose && println("Expanding the set of start solutions via gradient flow...")
+        for _ in 1:num_gradient_flow_starts
+            start_point = randn(k)
+            v = randn(k); v = v / norm(v);
+            prob = ODEProblem(g, start_point+0.001*v, tspan)
+            sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
+            convergence_point = last(sol.u)
+            improved_point = newton(r, convergence_point) |> solution
+            push!(new_pts, improved_point)
+        end
+        new_pts = HC.unique_points(new_pts)
+        verbose && println("Found $(length(new_pts)) routing points via gradient flow.")
+        start_parameters!(H, zeros(ComplexF64, length(p0)));
+        target_parameters!(H, p0);
+        s0_new_sols = HC.solve(H, new_pts) |> solutions
+        S0 = HC.unique_points([S0; s0_new_sols])
+        verbose && println("Traced to $(length(S0)-1) additional start solutions for the monodromy.")
+    end
+
+    ### Monodromy
     mon_result = monodromy_solve(
         MS,
         S0,
@@ -137,7 +164,7 @@ function critical_points(r::RoutingGradient,
         rand(UInt32);
     )
 
-    ### move to parameter = 0
+    ### Trace to ∇r=0
     intermediate_p = randn(ComplexF64, length(p0))
     start_parameters!(H, p0)
     target_parameters!(H, intermediate_p)
@@ -147,5 +174,11 @@ function critical_points(r::RoutingGradient,
     result = HomotopyContinuation.solve(H, result_intermediate)
 
     routing_points = real_solutions(result)
+
+    # Make sure none of the routing points found via gradient flow are lost
+    if num_gradient_flow_starts>0
+        routing_points = HC.unique_points([routing_points; real.(new_pts)])
+    end
+
     routing_points, result, mon_result
 end

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -91,7 +91,7 @@ end
 import HomotopyContinuation: MonodromyOptions, UniquePoints, EndgameTracker
 function critical_points(r::RoutingGradient,
                             S0::Union{AbstractVector{<:AbstractVector{<:Number}}, Nothing} = nothing,
-                            p0::Union{AbstractVector{<:Number}, Nothing} = nothing;
+                            rhs0::Union{AbstractVector{<:Number}, Nothing} = nothing;
                             verbose = true,
                             num_gradient_flow_starts = 100,
                             options = MonodromyOptions(parameter_sampler = p -> 10 .* randn(ComplexF64, length(p))),  
@@ -101,8 +101,8 @@ function critical_points(r::RoutingGradient,
     q1 = randn(k)
     H = RoutingPointsHomotopy(r, p1, q1)
 
-    ### Use monodromy to the system ∇r = p0 where we view the right-hand side are the parameters of the system
-    egtracker = EndgameTracker(H) # we want to add options later 
+    ### Use monodromy to the system ∇r = rhs0 where we view the right-hand side are the parameters of the system
+    egtracker = EndgameTracker(H) # we want to add options later
     trackers = [egtracker]
     x₀ = zeros(ComplexF64, size(H, k))
 
@@ -125,13 +125,13 @@ function critical_points(r::RoutingGradient,
     )
 
     #### set up start pair
-    if isnothing(p0) || isnothing(S0)
+    if isnothing(rhs0) || isnothing(S0)
         s0 = randn(ComplexF64, k)
-        p0 = evaluate(r, s0)
+        rhs0 = evaluate(r, s0)
         S0 = [s0]
     end
 
-    ### Expand S0: find solutions of ∇r=0 through gradient descent and trace to ∇r=p0
+    ### Expand S0: find solutions of ∇r=0 through gradient descent and trace to ∇r=rhs0
     new_pts = Vector{ComplexF64}[]
     g(x, param, t) = real(evaluate(r, x))
     tspan = (0.0, 1e4)
@@ -149,8 +149,8 @@ function critical_points(r::RoutingGradient,
         end
         new_pts = HC.unique_points(new_pts)
         verbose && println("Found $(length(new_pts)) routing points via gradient flow.")
-        start_parameters!(H, zeros(ComplexF64, length(p0)));
-        target_parameters!(H, p0);
+        start_parameters!(H, zeros(ComplexF64, length(rhs0)));
+        target_parameters!(H, rhs0);
         s0_new_sols = HC.solve(H, new_pts) |> solutions
         S0 = HC.unique_points([S0; s0_new_sols])
         verbose && println("Traced to $(length(S0)-1) additional start solutions for the monodromy.")
@@ -160,17 +160,17 @@ function critical_points(r::RoutingGradient,
     mon_result = monodromy_solve(
         MS,
         S0,
-        p0,
+        rhs0,
         rand(UInt32);
     )
 
     ### Trace to ∇r=0
-    intermediate_p = randn(ComplexF64, length(p0))
-    start_parameters!(H, p0)
-    target_parameters!(H, intermediate_p)
+    intermediate_rhs = randn(ComplexF64, length(rhs0))
+    start_parameters!(H, rhs0)
+    target_parameters!(H, intermediate_rhs)
     result_intermediate = HomotopyContinuation.solve(H, solutions(mon_result))
-    start_parameters!(H, intermediate_p)
-    target_parameters!(H, zeros(ComplexF64, length(p0)))
+    start_parameters!(H, intermediate_rhs)
+    target_parameters!(H, zeros(ComplexF64, length(rhs0)))
     result = HomotopyContinuation.solve(H, result_intermediate)
 
     routing_points = real_solutions(result)

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -94,6 +94,7 @@ function critical_points(r::RoutingGradient,
                             rhs0::Union{AbstractVector{<:Number}, Nothing} = nothing;
                             verbose = true,
                             num_gradient_flow_starts = 100,
+                            monodromy_at_zero = false,
                             options = MonodromyOptions(parameter_sampler = p -> 10 .* randn(ComplexF64, length(p))),  
                             seed = rand(UInt32))
     k = size(r, 2) # number of variables
@@ -125,10 +126,17 @@ function critical_points(r::RoutingGradient,
     )
 
     #### set up start pair
-    if isnothing(rhs0) || isnothing(S0)
-        s0 = randn(ComplexF64, k)
-        rhs0 = evaluate(r, s0)
-        S0 = [s0]
+    if !monodromy_at_zero
+        if isnothing(rhs0) || isnothing(S0)
+            s0 = randn(ComplexF64, k)
+            rhs0 = evaluate(r, s0)
+            S0 = [s0]
+        end
+    else
+        rhs0 = zeros(k)
+        if isnothing(S0)
+            S0 = Vector{ComplexF64}[]
+        end
     end
 
     ### Expand S0: find solutions of ∇r=0 through gradient descent and trace to ∇r=rhs0
@@ -149,11 +157,15 @@ function critical_points(r::RoutingGradient,
         end
         new_pts = HC.unique_points(new_pts)
         verbose && println("Found $(length(new_pts)) routing points via gradient flow.")
-        start_parameters!(H, zeros(ComplexF64, length(rhs0)));
-        target_parameters!(H, rhs0);
-        s0_new_sols = HC.solve(H, new_pts) |> solutions
-        S0 = HC.unique_points([S0; s0_new_sols])
-        verbose && println("Traced to $(length(S0)-1) additional start solutions for the monodromy.")
+        if !monodromy_at_zero
+            start_parameters!(H, zeros(ComplexF64, length(rhs0)));
+            target_parameters!(H, rhs0);
+            s0_new_sols = HC.solve(H, new_pts) |> solutions
+            S0 = HC.unique_points([S0; s0_new_sols])
+            verbose && println("Traced to $(length(S0)-1) additional start solutions for the monodromy.")
+        else
+            S0 = [S0; new_pts]
+        end
     end
 
     ### Monodromy
@@ -165,20 +177,25 @@ function critical_points(r::RoutingGradient,
     )
 
     ### Trace to ∇r=0
-    intermediate_rhs = randn(ComplexF64, length(rhs0))
-    start_parameters!(H, rhs0)
-    target_parameters!(H, intermediate_rhs)
-    result_intermediate = HomotopyContinuation.solve(H, solutions(mon_result))
-    start_parameters!(H, intermediate_rhs)
-    target_parameters!(H, zeros(ComplexF64, length(rhs0)))
-    result = HomotopyContinuation.solve(H, result_intermediate)
+    if !monodromy_at_zero
+        intermediate_rhs = randn(ComplexF64, length(rhs0))
+        start_parameters!(H, rhs0)
+        target_parameters!(H, intermediate_rhs)
+        result_intermediate = HomotopyContinuation.solve(H, solutions(mon_result))
+        start_parameters!(H, intermediate_rhs)
+        target_parameters!(H, zeros(ComplexF64, length(rhs0)))
+        result = HomotopyContinuation.solve(H, result_intermediate)
+        routing_points = real_solutions(result)
 
-    routing_points = real_solutions(result)
-
-    # Make sure none of the routing points found via gradient flow are lost
-    if num_gradient_flow_starts>0
-        routing_points = HC.unique_points([routing_points; real.(new_pts)])
+        # Make sure none of the routing points found via gradient flow are lost
+        if num_gradient_flow_starts>0
+            routing_points = HC.unique_points([routing_points; real.(new_pts)])
+        end
+        return routing_points, result, mon_result
+    else
+        routing_points = real_solutions(results(mon_result))
+        return routing_points, mon_result, mon_result
     end
 
-    routing_points, result, mon_result
+    return routing_points, result, mon_result
 end


### PR DESCRIPTION
The bottleneck in our approach is the **monodromy step**, where we solve the system $\nabla r(p)=\mathrm{rhs}_0$ for which the right-hand side is $\mathrm{rhs}_0=\nabla r(s_0)$ for a randomly generated start solutution $s_0\in\mathbb{C}^k$. We then trace the solutions of $\nabla r(p)=\mathrm{rhs}_0$ to solutions of $\nabla(p)=0$, and the real solutions are our desired routing points.

The monodromy solving takes a long time, partly because we need to be cautious with the stopping condition for the monodromy to avoid missing solutions. Since gradient flow is substantially faster, I suggest the following approach, based on a conversation with @PBrdng:

1. Run gradient flow with respect to $\nabla r$ from a large number of randomly generated start points in $\mathbb{R}^k$. This will give paths that converge to (real, index 0) solutions of $\nabla r=0$. 
2. Trace these solutions to a solutions of $\nabla r(p)=\mathrm{rhs}_0$.
3. Use all of these new solutions, along with $s_0$ as start solutions for the monodromy.

For the intermediate examples of interest (Kuramoto, Allee and 3RPRv0), the time for steps (1) and (2) when using 100 random start points for the gradient flow is around 2 minutes, which is negligible compared to the time spent on (3).

Based on experiments on smaller systems, steps (1) and (2) lead up a speed-up of (3), in addition to reducing the risk that we miss routing points. 