### PR TITLE
Newton's method to expand start solutions

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.4"
+julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "1b9bd339af92648de45dc519dccf96ec0bad77a4"
+project_hash = "3c24b15dfd60703764182f9bac0108f6b30c2513"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "8be2ae325471fc20b11c27bb34b518541d07dd3a"
@@ -2024,7 +2024,7 @@ uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.11.0"
 
 [[deps.ProjectedHypersurfaceRegions]]
-deps = ["DifferentialEquations", "HomotopyContinuation", "ImplicitPlots", "LightGraphs", "LinearAlgebra", "Plots", "ProgressMeter"]
+deps = ["DifferentialEquations", "HomotopyContinuation", "ImplicitPlots", "LightGraphs", "LinearAlgebra", "Plots", "ProgressMeter", "Reexport"]
 path = "."
 uuid = "ac67312b-5207-45cb-9b9f-8631313b0b45"
 version = "0.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -9,10 +9,12 @@ HomotopyContinuation = "f213a82b-91d6-5c5d-acf7-10f1c761b327"
 ImplicitPlots = "55ecb840-b828-11e9-1645-43f4a9f9ace7"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 LinearAlgebra = "1.12.0"
+Logging = "1.11.0"
 Reexport = "1.2.2"

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -153,8 +153,8 @@ function _expand_start_solutions(
     ProgressMeter.@showprogress for start_point in Iterators.product(grid...)
             start_pt .= start_point # this avoids allocations from splatting the tuple into the newton function
             # Newton's method on each initial guess
-            pt = newton(∇r, start_pt) |> solution
-            if norm(evaluate(∇r, pt)) < 1e-10
+            pt = newton(∇r, start_pt, rhs0; max_iters = 100) |> solution
+            if norm(evaluate(∇r, pt, rhs0)) < 1e-10
                 newton_success_count += 1
                 push!(new_pts, pt)
             end

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -144,12 +144,17 @@ function _expand_start_solutions(
         (start_grid_center[i]-w):start_grid_stepsize:(start_grid_center[i]+w) for
         i = 1:k
     ]
+    newton_w = 10*w
+    newton_grid = [
+        (start_grid_center[i]-newton_w):start_grid_stepsize:(start_grid_center[i]+newton_w) for
+        i = 1:k
+    ]
 
     # First we try to find start solutions via blindly applying Newton's method to ∇r=0.
     verbose && println("Expanding start solutions via Newton's method...")
     newton_success_count = 0
     start_pt = zeros(ComplexF64, k)
-    ProgressMeter.@showprogress for start_point in Iterators.product(grid...)
+    ProgressMeter.@showprogress for start_point in Iterators.product(newton_grid...)
             start_pt .= start_point # this avoids allocations from splatting the tuple into the newton function
             # Newton's method on each initial guess
             try
@@ -177,8 +182,8 @@ function _expand_start_solutions(
         empty!(new_pts)
     end
 
-    verbose && println("Successful Newton's method attempts: $(newton_success_count) out of $(length(grid[1])^k) ($(round(newton_success_count / (length(grid[1])^k) * 100, digits=2))%)")
-    verbose && println("Found $num_newton_pts solutions to ∇r(pt)=rhs0.")
+    verbose && println("Successful Newton's method attempts: $(newton_success_count) out of $(length(newton_grid[1])^k) ($(round(newton_success_count / (length(newton_grid[1])^k) * 100, digits=2))%)")
+    verbose && println("Found $num_newton_pts solutions to ∇r(z)=rhs0.")
     
     # Now we try gradient flow
     g(x, param, t) = real(evaluate(∇r, x))

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -124,7 +124,7 @@ function _expand_start_solutions(
     rhs0::AbstractVector{<:Number},
     k::Int;
     verbose = true,
-    newton_guesses = 10,
+    newton_guesses = 100,
     start_grid_width = 5,
     start_grid_stepsize = 0.2,
     start_grid_center = nothing,
@@ -152,8 +152,14 @@ function _expand_start_solutions(
             continue
         end
     end
+
+    if length(new_pts) > 0
+        new_pts = HC.unique_points(new_pts)
+        num_newton_pts = length(new_pts)
+    end
+
     verbose && println("Successful Newton's method attempts: $(newton_success_count) out of $(newton_guesses) ($(round(newton_success_count / (newton_guesses ) * 100, digits=2))%)")
-    verbose && println("Found $newton_success_count routing points via Newton's method.")
+    verbose && println("Found $num_newton_pts routing points via Newton's method.")
     
     # Now we try gradient flow
     if start_grid_width <= 0
@@ -174,7 +180,7 @@ function _expand_start_solutions(
         (start_grid_center[i]-w):start_grid_stepsize:(start_grid_center[i]+w) for
         i = 1:k
     ]
-    success_count = 0
+    gradient_success_count = 0
     ProgressMeter.@showprogress for start_point in Iterators.product(grid...)
         try
             prob = ODEProblem(g, collect(start_point), tspan)
@@ -182,7 +188,7 @@ function _expand_start_solutions(
             convergence_point = last(sol.u)
             improved_point = newton(∇r, convergence_point) |> solution
             push!(new_pts, improved_point)
-            success_count += 1                
+            gradient_success_count += 1                
         catch e
             continue
         end
@@ -190,8 +196,8 @@ function _expand_start_solutions(
     if length(new_pts) > 0
         new_pts = HC.unique_points(new_pts)
     end
-    verbose && println("Successful gradient flow attempts: $(success_count) out of $(length(grid[1])^k) ($(round(success_count / (length(grid[1])^k) * 100, digits=2))%)")
-    verbose && println("Found $(length(new_pts)) routing points via gradient flow.")
+    verbose && println("Successful gradient flow attempts: $(gradient_success_count) out of $(length(grid[1])^k) ($(round(gradient_success_count / (length(grid[1])^k) * 100, digits=2))%)")
+    verbose && println("Found $(length(new_pts)-num_newton_pts) routing points via gradient flow. (Total routing points found: $(length(new_pts)))")
 
     if !monodromy_at_zero
         start_parameters!(H, zeros(ComplexF64, length(rhs0)))

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -26,12 +26,15 @@ function critical_points(
 
     ∇r = RoutingGradient(r)
 
+
     # Step 1: Setup monodromy solver
     MS, H, S0, rhs0, k = _setup_monodromy_solver(
         ∇r, S0, rhs0;
         monodromy_at_zero = monodromy_at_zero,
         options = options,
     )
+    # Step 2a: Expand start solutions via Newton's method
+    new_pts = _newtons(∇r, rhs0)
 
     # Step 2: Expand start solutions via gradient flow
     S0, new_pts = _expand_start_solutions(
@@ -51,6 +54,28 @@ function critical_points(
     )
 end
 
+function _newtons(
+    ∇r::RoutingGradient,
+    rhs0::AbstractVector{<:Number}
+)
+    k = size(∇r, 2) # number of variables
+    initial_guesses = [randn(ComplexF64, k) for _ in 1:10]
+
+    pts = Vector{ComplexF64}[]
+
+    verbose && println("Attempting to find critical points via Newton's method...")
+    success_count = 0
+    for guess in initial_guesses
+        # Perform Newton's method on each initial guess
+        result = newton(∇r, guess) |> solution
+        if norm(evaluate(∇r, result)) < 1e-10
+            success_count += 1
+            push!(pts, result + rhs0)
+        end
+    end
+    println("Found $success_count critical points via Newton's method.")
+    return pts
+end
 
 """
     _setup_monodromy_solver(∇r, S0, rhs0; monodromy_at_zero, options)
@@ -167,7 +192,7 @@ function _expand_start_solutions(
     end
     verbose && println("Successful gradient flow attempts: $(success_count) out of $(length(grid[1])^k) ($(round(success_count / (length(grid[1])^k) * 100, digits=2))%)")
     verbose && println("Found $(length(new_pts)) routing points via gradient flow.")
-    
+
     if !monodromy_at_zero
         start_parameters!(H, zeros(ComplexF64, length(rhs0)))
         target_parameters!(H, rhs0)

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -140,7 +140,6 @@ function _expand_start_solutions(
         start_grid_center = zeros(k)
     end
 
-    verbose && println("Expanding start solutions via Newton's method...")
     w = (start_grid_width / 2)
     grid = [
         (start_grid_center[i]-w):start_grid_stepsize:(start_grid_center[i]+w) for
@@ -178,9 +177,11 @@ function _expand_start_solutions(
     verbose && println("Expanding the set of start solutions via gradient flow...")
 
     gradient_success_count = 0
+    start_pt = zeros(k)
     ProgressMeter.@showprogress for start_point in Iterators.product(grid...)
         try
-            prob = ODEProblem(g, collect(start_point), tspan)
+            start_pt .= start_point # this avoids allocations from splatting the tuple into the ODEProblem
+            prob = ODEProblem(g, start_pt, tspan)
             sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
             convergence_point = last(sol.u)
             improved_point = newton(∇r, convergence_point) |> solution

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -33,10 +33,8 @@ function critical_points(
         monodromy_at_zero = monodromy_at_zero,
         options = options,
     )
-    # Step 2a: Expand start solutions via Newton's method
-    new_pts = _newtons(∇r, rhs0)
 
-    # Step 2: Expand start solutions via gradient flow
+    # Step 2: Expand start solutions via Newton's method and gradient flow
     S0, new_pts = _expand_start_solutions(
         ∇r, H, S0, rhs0, k;
         verbose = verbose,
@@ -52,29 +50,6 @@ function critical_points(
         monodromy_at_zero = monodromy_at_zero,
         start_grid_width = start_grid_width,
     )
-end
-
-function _newtons(
-    ∇r::RoutingGradient,
-    rhs0::AbstractVector{<:Number}
-)
-    k = size(∇r, 2) # number of variables
-    initial_guesses = [randn(ComplexF64, k) for _ in 1:10]
-
-    pts = Vector{ComplexF64}[]
-
-    verbose && println("Attempting to find critical points via Newton's method...")
-    success_count = 0
-    for guess in initial_guesses
-        # Perform Newton's method on each initial guess
-        result = newton(∇r, guess) |> solution
-        if norm(evaluate(∇r, result)) < 1e-10
-            success_count += 1
-            push!(pts, result + rhs0)
-        end
-    end
-    println("Found $success_count critical points via Newton's method.")
-    return pts
 end
 
 """
@@ -149,13 +124,38 @@ function _expand_start_solutions(
     rhs0::AbstractVector{<:Number},
     k::Int;
     verbose = true,
+    newton_guesses = 10,
     start_grid_width = 5,
     start_grid_stepsize = 0.2,
     start_grid_center = nothing,
     monodromy_at_zero = false,
 )
     new_pts = Vector{ComplexF64}[]
+
+
+    # First we try to find start solutions via blindly applying Newton's method to ∇r=0.
+    verbose && println("Expanding start solutions via Newton's method...")
+
+    initial_guesses = [randn(Float64, k) for _ in 1:newton_guesses]
+
+    verbose && println("Attempting to find critical points via Newton's method...")
+    newton_success_count = 0
+    for guess in initial_guesses
+        try
+            # Newton's method on each initial guess
+            pt = newton(∇r, guess) |> solution
+            if norm(evaluate(∇r, pt)) < 1e-10
+                newton_success_count += 1
+                push!(new_pts, pt)
+            end
+        catch e
+            continue
+        end
+    end
+    verbose && println("Successful Newton's method attempts: $(newton_success_count) out of $(newton_guesses) ($(round(newton_success_count / (newton_guesses ) * 100, digits=2))%)")
+    verbose && println("Found $newton_success_count routing points via Newton's method.")
     
+    # Now we try gradient flow
     if start_grid_width <= 0
         return S0, new_pts
     end
@@ -166,7 +166,7 @@ function _expand_start_solutions(
     if isnothing(start_grid_center)
         start_grid_center = zeros(k)
     end
-
+    
     verbose && println("Expanding the set of start solutions via gradient flow...")
 
     w = (start_grid_width / 2)

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -130,7 +130,6 @@ function _expand_start_solutions(
     monodromy_at_zero = false,
 )
     new_pts = Vector{ComplexF64}[]
-
     # Setting up grid
     if start_grid_width <= 0
         return S0, new_pts
@@ -153,12 +152,16 @@ function _expand_start_solutions(
     ProgressMeter.@showprogress for start_point in Iterators.product(grid...)
             start_pt .= start_point # this avoids allocations from splatting the tuple into the newton function
             # Newton's method on each initial guess
-            pt = newton(∇r, start_pt, rhs0; max_iters = 100) |> solution
-            if norm(evaluate(∇r, pt, rhs0)) < 1e-10
-                newton_success_count += 1
-                push!(new_pts, pt)
+            try
+                pt = newton(∇r, start_pt, rhs0; max_iters = 200) |> solution
+                if norm(evaluate(∇r, pt, rhs0)) < 1e-10
+                    newton_success_count += 1
+                    push!(new_pts, pt)
+                end
+            catch e
+                continue
             end
-  
+
     end
 
     num_newton_pts = 0
@@ -167,8 +170,15 @@ function _expand_start_solutions(
         num_newton_pts += length(new_pts)
     end
 
+    # since the points obtained via Newton's method are already solutions to ∇r=rhs0, we can directly add them to S0 if monodromy_at_zero is false
+    if !monodromy_at_zero
+        S0 = HC.unique_points([S0; new_pts])
+        # to avoid redundant work later, we remove the points found via Newton's method from new_pts so that we aren't tracing them using monodromy
+        empty!(new_pts)
+    end
+
     verbose && println("Successful Newton's method attempts: $(newton_success_count) out of $(length(grid[1])^k) ($(round(newton_success_count / (length(grid[1])^k) * 100, digits=2))%)")
-    verbose && println("Found $num_newton_pts routing points via Newton's method.")
+    verbose && println("Found $num_newton_pts solutions to ∇r(pt)=rhs0.")
     
     # Now we try gradient flow
     g(x, param, t) = real(evaluate(∇r, x))
@@ -195,7 +205,7 @@ function _expand_start_solutions(
         new_pts = HC.unique_points(new_pts)
     end
     verbose && println("Successful gradient flow attempts: $(gradient_success_count) out of $(length(grid[1])^k) ($(round(gradient_success_count / (length(grid[1])^k) * 100, digits=2))%)")
-    verbose && println("Found $(length(new_pts)-num_newton_pts) routing points via gradient flow. (Total routing points found: $(length(new_pts)))")
+    verbose && println("Found $(length(new_pts)) routing points via gradient flow.")
 
     if !monodromy_at_zero
         start_parameters!(H, zeros(ComplexF64, length(rhs0)))

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -124,7 +124,6 @@ function _expand_start_solutions(
     rhs0::AbstractVector{<:Number},
     k::Int;
     verbose = true,
-    newton_guesses = 100,
     start_grid_width = 5,
     start_grid_stepsize = 0.2,
     start_grid_center = nothing,
@@ -132,54 +131,52 @@ function _expand_start_solutions(
 )
     new_pts = Vector{ComplexF64}[]
 
-
-    # First we try to find start solutions via blindly applying Newton's method to ∇r=0.
-    verbose && println("Expanding start solutions via Newton's method...")
-
-    initial_guesses = [randn(Float64, k) for _ in 1:newton_guesses]
-
-    verbose && println("Attempting to find critical points via Newton's method...")
-    newton_success_count = 0
-    for guess in initial_guesses
-        try
-            # Newton's method on each initial guess
-            pt = newton(∇r, guess) |> solution
-            if norm(evaluate(∇r, pt)) < 1e-10
-                newton_success_count += 1
-                push!(new_pts, pt)
-            end
-        catch e
-            continue
-        end
-    end
-
-    if length(new_pts) > 0
-        new_pts = HC.unique_points(new_pts)
-        num_newton_pts = length(new_pts)
-    end
-
-    verbose && println("Successful Newton's method attempts: $(newton_success_count) out of $(newton_guesses) ($(round(newton_success_count / (newton_guesses ) * 100, digits=2))%)")
-    verbose && println("Found $num_newton_pts routing points via Newton's method.")
-    
-    # Now we try gradient flow
+    # Setting up grid
     if start_grid_width <= 0
         return S0, new_pts
     end
 
-    g(x, param, t) = real(evaluate(∇r, x))
-    tspan = (0.0, 1e4)
-
     if isnothing(start_grid_center)
         start_grid_center = zeros(k)
     end
-    
-    verbose && println("Expanding the set of start solutions via gradient flow...")
 
+    verbose && println("Expanding start solutions via Newton's method...")
     w = (start_grid_width / 2)
     grid = [
         (start_grid_center[i]-w):start_grid_stepsize:(start_grid_center[i]+w) for
         i = 1:k
     ]
+
+    # First we try to find start solutions via blindly applying Newton's method to ∇r=0.
+    verbose && println("Expanding start solutions via Newton's method...")
+    newton_success_count = 0
+    start_pt = zeros(ComplexF64, k)
+    ProgressMeter.@showprogress for start_point in Iterators.product(grid...)
+            start_pt .= start_point # this avoids allocations from splatting the tuple into the newton function
+            # Newton's method on each initial guess
+            pt = newton(∇r, start_pt) |> solution
+            if norm(evaluate(∇r, pt)) < 1e-10
+                newton_success_count += 1
+                push!(new_pts, pt)
+            end
+  
+    end
+
+    num_newton_pts = 0
+    if length(new_pts) > 0
+        new_pts = HC.unique_points(new_pts)
+        num_newton_pts += length(new_pts)
+    end
+
+    verbose && println("Successful Newton's method attempts: $(newton_success_count) out of $(length(grid[1])^k) ($(round(newton_success_count / (length(grid[1])^k) * 100, digits=2))%)")
+    verbose && println("Found $num_newton_pts routing points via Newton's method.")
+    
+    # Now we try gradient flow
+    g(x, param, t) = real(evaluate(∇r, x))
+    tspan = (0.0, 1e4)
+    
+    verbose && println("Expanding the set of start solutions via gradient flow...")
+
     gradient_success_count = 0
     ProgressMeter.@showprogress for start_point in Iterators.product(grid...)
         try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 Pkg.activate(joinpath(@__DIR__, ".."))
 Pkg.instantiate()
 
-using Test, Random, ProjectedHypersurfaceRegions, LinearAlgebra
+using Test, Random, ProjectedHypersurfaceRegions, LinearAlgebra, Logging
 
 
 
@@ -243,8 +243,13 @@ end;
     Random.seed!(1234)
     @var a b x
     F = System([(x - a) * (x - b); 2 * x - (a + b)], variables=[a, b, x])
-    @test_logs match_mode = :any (:warn, r"(Irreducible component of higher multiplicity detected in the incidence variety\.|None of the provided solutions is a valid start solution \(Newton's method did not converge\)\.)") begin
+    PseudoWitnessSet(F, 2) 
+    Logging.with_logger(Test.TestLogger(; min_level=Logging.Debug)) do
+        logger = Logging.current_logger()
         PseudoWitnessSet(F, 2)
+        @test any(r -> r.level == Logging.Warn &&
+                       contains(r.message, "Irreducible component of higher multiplicity detected in the incidence variety."),
+                  logger.logs)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,7 @@ end
     MS, H, S0, rhs0, k = ProjectedHypersurfaceRegions._setup_monodromy_solver(∇r)
     S0, new_pts = ProjectedHypersurfaceRegions._expand_start_solutions(
         ∇r, H, S0, rhs0, k;
-        start_grid_width = 7,
+        start_grid_width = 10,
         start_grid_stepsize = 1,
     )
     @test length(S0) >= 5 # should find at least five new points (one for each local maximum)
@@ -243,7 +243,7 @@ end;
     Random.seed!(1234)
     @var a b x
     F = System([(x - a) * (x - b); 2 * x - (a + b)], variables=[a, b, x])
-    @test_logs match_mode = :any (:warn, "Irreducible component of higher multiplicity detected in the incidence variety.") begin
+    @test_logs match_mode = :any (:warn, r"(Irreducible component of higher multiplicity detected in the incidence variety\.|None of the provided solutions is a valid start solution \(Newton's method did not converge\)\.)") begin
         PseudoWitnessSet(F, 2)
     end
 end


### PR DESCRIPTION
This PR seeks to resolve #36. By naively applying Newton's method to \nabla r = 0 using random points in R^k, we can get some routing points for cheap. This strategy works in most of the test cases. 

In an email discussion with Oskar, he mentioned we could even try this with \nabla r - rhs0 = 0 and random points in C^k. This seems like an appropriate next step.

