### PR TITLE
Implement decomposition

### DIFF
--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -62,7 +62,19 @@ function PseudoWitnessSet(
     # Repopulate the solution set via monodromy (safetey feature if solutions were lost)
     M = monodromy_solve(F_L, solutions(E), L.p)
     Wt = solutions(M)
-    πW = unique_points([w[1:end-1] for w in Wt])
+    # πW = unique_points([w[1:k] for w in Wt])
+
+    unique_points = UniquePoints(first(Wt)[1:k], 1)
+    πW = Vector{Vector{ComplexF64}}()
+    fiber_representatives = Vector{Vector{ComplexF64}}()
+    for (i, vᵢ) in enumerate(Wt)
+        _, new_point = add!(unique_points, vᵢ[1:k], i)
+        if new_point
+            push!(πW, vᵢ[1:k])
+            push!(fiber_representatives, vᵢ)
+        end
+    end
+    Wt = fiber_representatives
 
     # Set up tracker 
     tracker = Tracker(ParameterHomotopy(fixed(F_L; compile = compile), L.p, L.p))

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -67,7 +67,7 @@ function PseudoWitnessSet(
     # πW = unique_points([w[1:k] for w in Wt])
 
     if length(Wt)==0
-        @error "No witness points found."
+        error("No witness points found.")
     end
     
     unique_points = UniquePoints(first(Wt)[1:k], 1)

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -59,11 +59,17 @@ function PseudoWitnessSet(
         @warn "Irreducible component of higher multiplicity detected in the incidence variety."
     end
 
+
+
     # Repopulate the solution set via monodromy (safetey feature if solutions were lost)
     M = monodromy_solve(F_L, solutions(E), L.p)
     Wt = solutions(M)
     # πW = unique_points([w[1:k] for w in Wt])
 
+    if length(Wt)==0
+        @error "No witness points found."
+    end
+    
     unique_points = UniquePoints(first(Wt)[1:k], 1)
     πW = Vector{Vector{ComplexF64}}()
     fiber_representatives = Vector{Vector{ComplexF64}}()

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -9,10 +9,11 @@ struct PseudoWitnessSet
     k::Int
     L::Line
     Wt::Vector
+    πW::Vector
     tracker::EndgameTracker
     track_report::Vector{Bool}
 end
-degree(PWS::PseudoWitnessSet) = length(PWS.Wt)
+degree(PWS::PseudoWitnessSet) = length(PWS.πW)
 total_dim(PWS::PseudoWitnessSet) = size(PWS.F, 2)
 n_projection_variables(PWS::PseudoWitnessSet) = PWS.k
 system(PWS::PseudoWitnessSet) = PWS.F
@@ -61,15 +62,16 @@ function PseudoWitnessSet(
     # Repopulate the solution set via monodromy (safetey feature if solutions were lost)
     M = monodromy_solve(F_L, solutions(E), L.p)
     Wt = solutions(M)
+    πW = unique_points([w[1:end-1] for w in Wt])
 
     # Set up tracker 
     tracker = Tracker(ParameterHomotopy(fixed(F_L; compile = compile), L.p, L.p))
     track_report = zeros(Bool, length(solutions(M))) # for keeping track of which paths are successful
 
-    PseudoWitnessSet(F, k, L, Wt, EndgameTracker(tracker), track_report)
+    PseudoWitnessSet(F, k, L, Wt, πW, EndgameTracker(tracker), track_report)
 end
 
-witness_points(PWS::PseudoWitnessSet) = [w[1:end-1] for w in PWS.Wt]
+witness_points(PWS::PseudoWitnessSet) = PWS.πW
 
 function track!(u::Vector, PWS::PseudoWitnessSet, p)
     tracker = PWS.tracker

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -10,6 +10,7 @@ struct PseudoWitnessSet
     L::Line
     Wt::Vector
     πW::Vector
+    W::WitnessSet
     tracker::EndgameTracker
     track_report::Vector{Bool}
 end
@@ -59,12 +60,14 @@ function PseudoWitnessSet(
         @warn "Irreducible component of higher multiplicity detected in the incidence variety."
     end
 
-
-
     # Repopulate the solution set via monodromy (safetey feature if solutions were lost)
     M = monodromy_solve(F_L, solutions(E), L.p)
     Wt = solutions(M)
-    # πW = unique_points([w[1:k] for w in Wt])
+
+    # Form a WitnessSet
+    A = transpose(L.b) |> nullspace |> transpose
+    b = A * L.p
+    W = WitnessSet(CompiledSystem(F), LinearSubspace(A, b), [w[1:end-1] for w in Wt])
 
     if length(Wt)==0
         error("No witness points found.")

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -89,7 +89,7 @@ function PseudoWitnessSet(
     tracker = Tracker(ParameterHomotopy(fixed(F_L; compile = compile), L.p, L.p))
     track_report = zeros(Bool, length(solutions(M))) # for keeping track of which paths are successful
 
-    PseudoWitnessSet(F, k, L, Wt, πW, EndgameTracker(tracker), track_report)
+    PseudoWitnessSet(F, k, L, Wt, πW, W, EndgameTracker(tracker), track_report)
 end
 
 witness_points(PWS::PseudoWitnessSet) = PWS.πW

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,12 +251,6 @@ end;
 
 end;
 
-#@testset "Multiplicity detection" begin
-    ## We need an example where the discriminant has a component of multiplicity > 1, but its not the entire discriminant. 
-    # I think one way to do this is to start with the the thing you want to project to, e.g. (a-b)^2*c = 0. 
-    # Then, introduce a new variable x that we will eliminate. Do a GL action of a,b,c -- that is, replace each with some linear combination of a,b,c, and x. Then, the resulting system will have the same discriminant, but now it will be a projection from a higher dimensional space, so we can test that we detect the multiplicity of the (a-b)^2 component without the entire discriminant being multiplicity > 1.
-#end
-
 @testset "Empty PWS" begin
     Random.seed!(1234)
     @var a b x
@@ -325,4 +319,17 @@ end
     # V(F) has two irreducible components that project down to V(a^2-4b)
     h = ProjectedHypersurface(F, [a, b])
     @test degree(h) == 2
+end
+
+@testset "Multiplicity detection" begin
+    @var a, b, x
+    F = System([a^2 - 4*b, (x - a + 1)^2 * (x - a)], variables=[a, b, x])
+    PseudoWitnessSet(F, 2) 
+    Logging.with_logger(Test.TestLogger(; min_level=Logging.Debug)) do
+        logger = Logging.current_logger()
+        PseudoWitnessSet(F, 2)
+        @test any(r -> r.level == Logging.Warn &&
+                       contains(r.message, "Irreducible component of higher multiplicity detected in the incidence variety."),
+                  logger.logs)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,14 +310,11 @@ end
     F = System([z-x^2, y], variables = [x,y, z])
     h = ProjectedHypersurface(F, [y, z])
 
-    @test degree(h)==1
-    @test length(h.PWS.Wt) == 2
-
+    @test degree(h)==1 # the downstairs degree should be 1
+    @test length(h.PWS.Wt) == 1 # we should only keep one witness point upstairs
 
     # h(y,z) = y (up to a constant)
-
     # gradient(h, [y, z]) = [1/y, 0]
-    gradient(h, [2, 3]) 
-
+    @test gradient(h, [2, 3]) - [1/2, 0] |> norm < 1e-6
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,6 @@ Pkg.instantiate()
 
 using Test, Random, ProjectedHypersurfaceRegions, LinearAlgebra, Logging
 
-
-
 @testset "Quadratic discriminant" begin
     
     @var a b x
@@ -298,5 +296,23 @@ end
     Hess_log_abs_h = p -> [[2/(p[1]^2 - 4*p[2]) - 4*p[1]^2/(p[1]^2 - 4*p[2])^2 8*p[1]/(p[1]^2 - 4*p[2])^2]; 
     [8*p[1]/(p[1]^2 - 4*p[2])^2  -16/(p[1]^2 - 4*p[2])^2]]
     @test Hess_log_abs_h(pt) - ProjectedHypersurfaceRegions.gradient_and_hessian(h, pt)[2] |> norm < 1e-6
+
+end
+
+
+@testset "Noninjective projection" begin
+    @var x y z
+    F = System([z-x^2, y], variables = [x,y, z])
+    h = ProjectedHypersurface(F, [y, z])
+
+    @test degree(h)==1
+    @test length(h.PWS.Wt) == 2
+
+
+    # h(y,z) = y (up to a constant)
+
+    # gradient(h, [y, z]) = [1/y, 0]
+    gradient(h, [2, 3]) 
+
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,3 +318,11 @@ end
     @test gradient(h, [2, 3]) - [1/2, 0] |> norm < 1e-6
 
 end
+
+@testset "Two components projecting to the same hypersurface" begin
+    @var a, b, x
+    F = System([a^2 - 4*b, (x - a + 1) * (x - a)], variables=[a, b, x])
+    # V(F) has two irreducible components that project down to V(a^2-4b)
+    h = ProjectedHypersurface(F, [a, b])
+    @test degree(h) == 2
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,6 +251,11 @@ end;
 
 end;
 
+@testset "Multiplicity detection" begin
+    @var a, b, x
+    F = System([a^2 - 4*b, (x - a + 1)^2 * (x - a)], variables=[a, b, x])
+    @test_logs (:warn, "Irreducible component of higher multiplicity detected in the incidence variety.") match_mode=:any PseudoWitnessSet(F,2)
+end
 @testset "Empty PWS" begin
     Random.seed!(1234)
     @var a b x
@@ -319,17 +324,4 @@ end
     # V(F) has two irreducible components that project down to V(a^2-4b)
     h = ProjectedHypersurface(F, [a, b])
     @test degree(h) == 2
-end
-
-@testset "Multiplicity detection" begin
-    @var a, b, x
-    F = System([a^2 - 4*b, (x - a + 1)^2 * (x - a)], variables=[a, b, x])
-    PseudoWitnessSet(F, 2) 
-    Logging.with_logger(Test.TestLogger(; min_level=Logging.Debug)) do
-        logger = Logging.current_logger()
-        PseudoWitnessSet(F, 2)
-        @test any(r -> r.level == Logging.Warn &&
-                       contains(r.message, "Irreducible component of higher multiplicity detected in the incidence variety."),
-                  logger.logs)
-    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,17 +251,22 @@ end;
 
 end;
 
-@testset "Multiplicity detection" begin
+#@testset "Multiplicity detection" begin
+    ## We need an example where the discriminant has a component of multiplicity > 1, but its not the entire discriminant. 
+    # I think one way to do this is to start with the the thing you want to project to, e.g. (a-b)^2*c = 0. 
+    # Then, introduce a new variable x that we will eliminate. Do a GL action of a,b,c -- that is, replace each with some linear combination of a,b,c, and x. Then, the resulting system will have the same discriminant, but now it will be a projection from a higher dimensional space, so we can test that we detect the multiplicity of the (a-b)^2 component without the entire discriminant being multiplicity > 1.
+#end
+
+@testset "Empty PWS" begin
     Random.seed!(1234)
     @var a b x
     F = System([(x - a) * (x - b); 2 * x - (a + b)], variables=[a, b, x])
-    PseudoWitnessSet(F, 2) 
-    Logging.with_logger(Test.TestLogger(; min_level=Logging.Debug)) do
-        logger = Logging.current_logger()
-        PseudoWitnessSet(F, 2)
-        @test any(r -> r.level == Logging.Warn &&
-                       contains(r.message, "Irreducible component of higher multiplicity detected in the incidence variety."),
-                  logger.logs)
+
+    # For this example, (x-a)(x-b) = x^2 - (a+b)x  + ab, so the disc = a^2 + b^2 - 2ab = (a-b)^2. The discriminant is the line b=a with multiplicity 2. 
+    # BUT, we have a concurrent error with an empty witness set.
+    try PseudoWitnessSet(F,2) catch e 
+        @test isa(e, ErrorException)
+        @test contains(e.msg, "No witness points found.")
     end
 end
 


### PR DESCRIPTION
This aims to resolve #54.

Together with @dave-k-johnson, we today added the upstairs witness set `W` as part of the PWS structure.

Plan:

- Implement a function `decompose(h::ProjectedHypersurface)` which runs `HomotopyContinuation.decompose(h.PWS.W)` and uses the output to form a vector of `ProjectedHypersurface`'s.
- Before outputting, run a membership test to check pairwise equality of the ProjectedHyperfaces and remove redundancies. 

The second bullet point might require implementing a membership test of pseudo-witness sets?