### PR TITLE
Add support for noninjective projections

### DIFF
--- a/examples/allee_radical.jl
+++ b/examples/allee_radical.jl
@@ -39,7 +39,7 @@ h_sq = ProjectedHypersurface(F_sq, [a, b])
 PWS_sq = h_sq.PWS
 
 # Check which witness points solve the original systems 
-sort(log.(norm.(F.(solutions(h_sq.PWS.W))))) |> plot
+sort(log.(norm.(F.(h_sq.PWS.W)))) |> plot
 
 # Pick a tolerance
 tol = 1e-6

--- a/examples/allee_radical.jl
+++ b/examples/allee_radical.jl
@@ -36,25 +36,9 @@ radical_generators = [p[1]*x[1] + p[1]*x[2] - 2*p[1]*x[3] + p[2]*x[3]^2 - p[2]*x
 F_radical = System(radical_generators, variables = [a; b; x])
 F_sq = System(randn(4, length(F_radical)) * radical_generators, variables = [a; b; x])
 h_sq = ProjectedHypersurface(F_sq, [a, b])
-PWS_sq = h_sq.PWS
-
-# Check which witness points solve the original systems 
 sort(log.(norm.(F.(h_sq.PWS.W)))) |> plot
 
-# Pick a tolerance
-tol = 1e-6
-
-# Filter out the relevant solutions and build a new routing function
-filter = findall(pt->norm(F(pt))<tol, solutions(h_sq.PWS.W))
-PWS_new = PseudoWitnessSet(
-    PWS_sq.F, 
-    PWS_sq.k, 
-    PWS_sq.L, 
-    PWS_sq.tz[filter], 
-    PWS_sq.tracker,
-    PWS_sq.track_report[filter]
-)
-
+PWS_new = PseudoWitnessSet(F_sq, 2, filter_condition = (pt -> norm(F(pt)) < 1e-6))
 
 h = ProjectedHypersurface(F, [a, b]; PWS=PWS_new)
 r = RoutingFunction(h; c=[0.02,0.2], g = [a,b, b-0.5])
@@ -105,18 +89,30 @@ savefig("figures/allee_original_zoomed_in.svg")
 # ROUTING FUNCTION FROM RADICAL GENERATORS
 
 # Previously computed routing points
-pts = [
-    [0.0488373189929933, 0.17529504250751],
-    [1.2278101836407234, 0.27333352325137683],
-    [0.03649953760686965, 0.19538098740286294],
-    [0.019221143323682563, 0.3403529277188622],
-    [0.002012479240850282, 0.40953865518224003],
-    [0.03600678060438847, 0.36033495215448375],
-    [0.046225501340473096, 0.47852790907543874]
+pts = [[0.055589798001425106, 0.20458114869092572]
+    [1.087677447086965, 0.283186049925421]
+    [0.03893320710527537, 0.22760515612129203]
+    [0.0207223762777128, 0.3497569506736974]
+    [0.005192953854625316, 0.3934392610042774]
+    [0.03634241483471314, 0.3616901975928537]
+    [0.0468647920529527, 0.4669511862715351]
 ]
 
 # Check that all points are critical
 ∇r.(pts)
+
+g(x, param, t) = real(evaluate(∇r, x))
+tspan = (0.0, 1e4)
+map(pts) do pt
+    start_pt .= pt
+    prob = SciMLBase.ODEProblem(g, start_pt, tspan)
+    sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
+    last(sol.u)
+end
+
+scatter!(Tuple.(improved_pts))
+
+
 
 G, idx, failed_info = partition_of_critical_points(r, pts)
 

--- a/examples/allee_radical.jl
+++ b/examples/allee_radical.jl
@@ -101,19 +101,6 @@ pts = [[0.055589798001425106, 0.20458114869092572]
 # Check that all points are critical
 ∇r.(pts)
 
-g(x, param, t) = real(evaluate(∇r, x))
-tspan = (0.0, 1e4)
-map(pts) do pt
-    start_pt .= pt
-    prob = SciMLBase.ODEProblem(g, start_pt, tspan)
-    sol = DE.solve(prob, reltol = 1e-6, abstol = 1e-6)
-    last(sol.u)
-end
-
-scatter!(Tuple.(improved_pts))
-
-
-
 G, idx, failed_info = partition_of_critical_points(r, pts)
 
 pl_radical_smaller = generate_plot(

--- a/examples/allee_radical.jl
+++ b/examples/allee_radical.jl
@@ -39,18 +39,18 @@ h_sq = ProjectedHypersurface(F_sq, [a, b])
 PWS_sq = h_sq.PWS
 
 # Check which witness points solve the original systems 
-sort(log.(norm.(F.(witness_points(h_sq.PWS))))) |> plot
+sort(log.(norm.(F.(solutions(h_sq.PWS.W))))) |> plot
 
 # Pick a tolerance
 tol = 1e-6
 
 # Filter out the relevant solutions and build a new routing function
-filter = findall(pt->norm(F(pt))<tol, witness_points(h_sq.PWS))
+filter = findall(pt->norm(F(pt))<tol, solutions(h_sq.PWS.W))
 PWS_new = PseudoWitnessSet(
     PWS_sq.F, 
     PWS_sq.k, 
     PWS_sq.L, 
-    PWS_sq.tW[filter], 
+    PWS_sq.tz[filter], 
     PWS_sq.tracker,
     PWS_sq.track_report[filter]
 )

--- a/src/gradient_cache.jl
+++ b/src/gradient_cache.jl
@@ -122,7 +122,7 @@ function GradientCache(PWS)
     UB = zeros(ComplexF64, d, n - k, k)
     A = zeros(ComplexF64, d, N, k, k) 
 
-    JsuF, JPF, JBF, HF, JxB, JxP, JPB = compute_systems(F, n, k, L.b)
+    JsuF, JPF, JBF, HF, JxB, JxP, JPB = compute_systems(F, n, k, L.direction)
 
 
     # 

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -1,8 +1,8 @@
-export PseudoWitnessSet, degree, total_dim, system, witness_points
+export PseudoWitnessSet, degree, total_dim, system
 struct Line{T<:Number}
     point::Vector{T}
-    direction::Vector{T},
-    linear_subspace::LinearSubspace,
+    direction::Vector{T}
+    linear_subspace::LinearSubspace
 end
 
 function Line(point::Vector{T}, direction::Vector{T}) where T<:Number
@@ -16,11 +16,13 @@ struct PseudoWitnessSet{TF<:System,T<:Number,TT}
     F::TF
     k::Int
     L::Line{T}
-    tW::Vector{Vector{ComplexF64}}
+    W::WitnessSet # WitnessSet for the upstairs variety
+    πW::Vector{Vector{ComplexF64}} # Projections of the upstairs witness points (without duplicates)
+    tZ::Vector{Vector{ComplexF64}} # Restricted coordinates of the witness points used for tracking (one per fiber)
     tracker::TT
     track_report::Vector{Bool}
 end
-degree(PWS::PseudoWitnessSet) = length(PWS.tW)
+degree(PWS::PseudoWitnessSet) = length(PWS.πW)
 total_dim(PWS::PseudoWitnessSet) = size(PWS.F, 2)
 n_projection_variables(PWS::PseudoWitnessSet) = PWS.k
 system(PWS::PseudoWitnessSet) = PWS.F
@@ -62,9 +64,9 @@ function PseudoWitnessSet(
     t = F_L.t
     G = System([F.expressions; p + t .* L.direction - v[1:k]], variables = [t; v], parameters = p)
 
-    # Trace the nonsingular solutions 
+    # Trace the nonsingular solutions
     E = HC.solve(G; start_system = start_system,
-                    target_parameters = L.p)
+                    target_parameters = L.point)
 
      # Check for singular solutions
     if nsingular(E) > 0
@@ -75,43 +77,52 @@ function PseudoWitnessSet(
     # TODO: Make a trace test here?
     M = monodromy_solve(G, solutions(E), L.point)
     n = length(v)
-    # Keep only the restricted coordinates [t; w] used by the restricted tracker.
-    tW = map(s -> ComplexF64[s[1]; s[(k+2):end]], solutions(M))
+
+    tW = solutions(M)
+
+    # Raise exception if we didn't find any witness points
+    if length(tW) == 0
+        error("No witness points found.")
+    end
+
+    # Witness set for the upstairs variety
+    W = WitnessSet(CompiledSystem(F), L.linear_subspace, [tw[2:end] for tw in tW])
+
+    # Form πW (the projections of the upstairs witness points without dublicates)
+    # For each unique downstairs point, keep one fiber representative in in tZ
+    unique_points = UniquePoints(first(tW)[2:k+1], 1)
+    πW = Vector{Vector{ComplexF64}}()
+    tZ = Vector{Vector{ComplexF64}}()
+    for (i, tw) in enumerate(tW)
+        _, new_point = add!(unique_points, tw[2:k+1], i)
+        if new_point
+            push!(πW, tw[2:k+1])
+            push!(tZ, [tw[1]; tw[k+2:end]])
+        end
+    end
 
     # Set up tracker 
     tracker = Tracker(ParameterHomotopy(F_L, L.point, L.point))
     track_report = zeros(Bool, length(solutions(M))) # for keeping track of which paths are successful
 
+    # Return the pseudo-witness set
     PseudoWitnessSet{typeof(F),ComplexF64,typeof(EndgameTracker(tracker))}(
         F,
         k,
         L,
-        tW,
+        W,
+        πW,
+        tZ,
         EndgameTracker(tracker),
         track_report,
     )
-end
-
-function witness_points(PWS::PseudoWitnessSet)
-    k = n_projection_variables(PWS)
-    p = PWS.L.p
-    b = PWS.L.b
-    map(PWS.tW) do tw
-        t = tw[1]
-        w = tw[2:end]
-        v = similar(p, ComplexF64, k)
-        @inbounds for i = 1:k
-            v[i] = p[i] + t * b[i]
-        end
-        ComplexF64[v; w]
-    end
 end
 
 function track!(u::Vector{Vector{ComplexF64}}, PWS::PseudoWitnessSet, p::AbstractVector)
     tracker = PWS.tracker
     target_parameters!(tracker, p)
     # Update one tracker instance in place for each target parameter.
-    for (l, w) in enumerate(PWS.tW)
+    for (l, w) in enumerate(PWS.tZ)
             HC.track!(tracker, w, 1)
             copyto!(u[l], tracker.tracker.state.x)
             PWS.track_report[l] = all(isfinite, u[l]) # note if the track was successful or not

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -103,7 +103,7 @@ function PseudoWitnessSet(
 
     # Set up tracker 
     tracker = Tracker(ParameterHomotopy(F_L, L.point, L.point))
-    track_report = zeros(Bool, length(solutions(M))) # for keeping track of which paths are successful
+    track_report = zeros(Bool, length(tZ)) # for keeping track of which paths are successful
 
     # Return the pseudo-witness set
     PseudoWitnessSet{typeof(F),ComplexF64,typeof(EndgameTracker(tracker))}(

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -47,7 +47,8 @@ function PseudoWitnessSet(
     k::Int;
     L::Union{Line, Nothing} = nothing,
     start_system::Symbol = :total_degree,
-    compile::Union{Bool,Symbol} = :mixed 
+    compile::Union{Bool,Symbol} = :mixed,
+    filter_condition::Union{Function,Nothing} = nothing,
 )
  
     if isnothing(L)
@@ -80,12 +81,15 @@ function PseudoWitnessSet(
 
     tW = solutions(M)
 
+    if !isnothing(filter_condition)
+        tW = filter(tw -> filter_condition(tw[2:end]), tW)
+    end
+
     # Raise exception if we didn't find any witness points
     if length(tW) == 0
         error("No witness points found.")
     end
 
-    # The full set of unprojected witness points
     W = [tw[2:end] for tw in tW]
 
     # Form πW (the projections of the upstairs witness points without dublicates)

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -16,7 +16,7 @@ struct PseudoWitnessSet{TF<:System,T<:Number,TT}
     F::TF
     k::Int
     L::Line{T}
-    W::WitnessSet # WitnessSet for the upstairs variety
+    W::Vector{Vector{ComplexF64}} # Unprojected witness points
     πW::Vector{Vector{ComplexF64}} # Projections of the upstairs witness points (without duplicates)
     tZ::Vector{Vector{ComplexF64}} # Restricted coordinates of the witness points used for tracking (one per fiber)
     tracker::TT
@@ -85,8 +85,8 @@ function PseudoWitnessSet(
         error("No witness points found.")
     end
 
-    # Witness set for the upstairs variety
-    W = WitnessSet(CompiledSystem(F), L.linear_subspace, [tw[2:end] for tw in tW])
+    # The full set of unprojected witness points
+    W = [tw[2:end] for tw in tW]
 
     # Form πW (the projections of the upstairs witness points without dublicates)
     # For each unique downstairs point, keep one fiber representative in in tZ

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -1,7 +1,15 @@
 export PseudoWitnessSet, degree, total_dim, system, witness_points
 struct Line{T<:Number}
-    p::Vector{T}
-    b::Vector{T}
+    point::Vector{T}
+    direction::Vector{T},
+    linear_subspace::LinearSubspace,
+end
+
+function Line(point::Vector{T}, direction::Vector{T}) where T<:Number
+    A = transpose(direction) |> nullspace |> transpose
+    b = A * point
+    L = LinearSubspace(A, b)
+    Line(point, direction, L)
 end
 
 struct PseudoWitnessSet{TF<:System,T<:Number,TT}
@@ -44,15 +52,15 @@ function PseudoWitnessSet(
         L = Line(randn(ComplexF64, k), randn(ComplexF64, k))
     end
     
-    # Restrict the ambient system to F([p + t * L.b; w]) with p as the parameter.
-    F_L = RestrictionToLineSystem(F, L.b, k; compile = compile)
+    # Restrict the ambient system to F([p + t * L.direction; w]) with p as the parameter.
+    F_L = RestrictionToLineSystem(F, L.direction, k; compile = compile)
 
     # Intersect with random linear subspace
-    # we want to use G = [F.expressions; p + t .* L.b - v[1:k]] instead of F_L to be able to use polyhedral/total_degree
+    # we want to use G = [F.expressions; p + t .* L.direction - v[1:k]] instead of F_L to be able to use polyhedral/total_degree
     v = variables(F)
     p = F_L.parameters
     t = F_L.t
-    G = System([F.expressions; p + t .* L.b - v[1:k]], variables = [t; v], parameters = p)
+    G = System([F.expressions; p + t .* L.direction - v[1:k]], variables = [t; v], parameters = p)
 
     # Trace the nonsingular solutions 
     E = HC.solve(G; start_system = start_system,
@@ -64,14 +72,14 @@ function PseudoWitnessSet(
     end
 
     # Repopulate the solution set via monodromy (safetey feature if solutions were lost)
-    M = monodromy_solve(G, solutions(E), L.p)
+    # TODO: Make a trace test here?
+    M = monodromy_solve(G, solutions(E), L.point)
     n = length(v)
     # Keep only the restricted coordinates [t; w] used by the restricted tracker.
     tW = map(s -> ComplexF64[s[1]; s[(k+2):end]], solutions(M))
 
     # Set up tracker 
-    
-    tracker = Tracker(ParameterHomotopy(F_L, L.p, L.p))
+    tracker = Tracker(ParameterHomotopy(F_L, L.point, L.point))
     track_report = zeros(Bool, length(solutions(M))) # for keeping track of which paths are successful
 
     PseudoWitnessSet{typeof(F),ComplexF64,typeof(EndgameTracker(tracker))}(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,7 +290,6 @@ end
     h = ProjectedHypersurface(F, [y, z])
 
     @test degree(h) == 1 # the downstairs degree should be 1
-    @test solutions(h.PWS.W) |> length  == 2 # the full witness set should have 2 points 
 
     # h(y,z) = y (up to a constant) so gradient(h, [y, z]) = [1/y, 0]
     @test gradient(h, [2, 3]) - [1/2, 0] |> norm < 1e-6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,22 +252,6 @@ end;
     @test isempty(failed_info)
 
 end;
-
-@testset "Multiplicity detection" begin
-    Random.seed!(1234)
-    @var a b x
-    F = System([(x - a) * (x - b); 2 * x - (a + b)], variables=[a, b, x])
-    PseudoWitnessSet(F, 2) 
-    Logging.with_logger(Test.TestLogger(; min_level=Logging.Debug)) do
-        logger = Logging.current_logger()
-        PseudoWitnessSet(F, 2)
-        @test any(r -> r.level == Logging.Warn &&
-                       contains(r.message, "Irreducible component of higher multiplicity detected in the incidence variety."),
-                  logger.logs)
-    end
-end
-
-
 @testset "Hypersurface evaluations for quadratic" begin
 
     # Set up the system
@@ -299,4 +283,37 @@ end
     [8*p[1]/(p[1]^2 - 4*p[2])^2  -16/(p[1]^2 - 4*p[2])^2]]
     @test Hess_log_abs_h(pt) - ProjectedHypersurfaceRegions.gradient_and_hessian(h, pt)[2] |> norm < 1e-6
 
+end
+@testset "Noninjective projection" begin
+    @var x y z
+    F = System([z-x^2, y], variables = [x,y, z])
+    h = ProjectedHypersurface(F, [y, z])
+
+    @test degree(h) == 1 # the downstairs degree should be 1
+    @test solutions(h.PWS.W) |> length  == 2 # the full witness set should have 2 points 
+
+    # h(y,z) = y (up to a constant) so gradient(h, [y, z]) = [1/y, 0]
+    @test gradient(h, [2, 3]) - [1/2, 0] |> norm < 1e-6
+
+end
+
+@testset "Two components projecting to the same hypersurface" begin
+    @var a, b, x
+    F = System([a^2 - 4*b, (x - a + 1) * (x - a)], variables=[a, b, x])
+    # V(F) has two irreducible components that project down to V(a^2-4b)
+    h = ProjectedHypersurface(F, [a, b])
+    @test degree(h) == 2
+end
+
+@testset "Empty PWS" begin
+    Random.seed!(1234)
+    @var a b x
+    F = System([(x - a) * (x - b); 2 * x - (a + b)], variables=[a, b, x])
+    @test_throws "No witness points found." PseudoWitnessSet(F, 2)
+end
+
+@testset "Multiplicity detection" begin
+    @var a, b, x
+    F = System([a^2 - 4*b, (x - a + 1)^2 * (x - a)], variables=[a, b, x])
+    @test_logs (:warn, "Irreducible component of higher multiplicity detected in the incidence variety.") match_mode=:any PseudoWitnessSet(F,2)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -284,7 +284,7 @@ end
     # Test the evaluation formula
     pt = [1, 1]
     log_abs_h = p -> log(abs(p[1]^2 - 4*p[2]))
-    direction = h.PWS.L.b
+    direction = h.PWS.L.direction
     C = log(abs(direction[1]^2))
     @test h(pt) + C - log_abs_h(pt) |> abs < 1e-6
 


### PR DESCRIPTION
We have changed the PWS struct and its constructor to be able to accommodate the case when $\pi\colon V(F)\to V(h)$ is not injective.

- We now store all the upstairs witness points as a field `W` of the PWS.
- We store the projections as a field `πW` where we use `unique_points` to avoid duplicates.
- The degree of a PWS is now simply `length(πW)`.
- For each projected point in `πW`, we store a **single point** from its fiber, in the form of a t coordinate and the upstairs coordinate ($z$ in the notation of the paper). This is stored in the field `tZ` and is used for subsequent tracking.

This resolves #56.