### PR TITLE
Add trace test

### DIFF
--- a/examples/allee_radical.jl
+++ b/examples/allee_radical.jl
@@ -4,7 +4,7 @@
 
 using Random, Plots, LinearAlgebra,  ImplicitPlots, ProjectedHypersurfaceRegions
 
-Random.seed!(1234)
+Random.seed!(123)
 
 # Set up incidence variety of discriminant
 @var a b x[1:3]
@@ -38,9 +38,13 @@ F_sq = System(randn(4, length(F_radical)) * radical_generators, variables = [a; 
 h_sq = ProjectedHypersurface(F_sq, [a, b])
 sort(log.(norm.(F.(h_sq.PWS.W)))) |> plot
 
-PWS_new = PseudoWitnessSet(F_sq, 2, filter_condition = (pt -> norm(F(pt)) < 1e-6))
+PWS_new = PseudoWitnessSet(F_sq, 2, filter_condition = (pt -> norm(F(pt)) < 1e-4))
 
 h = ProjectedHypersurface(F, [a, b]; PWS=PWS_new)
+degree(h)
+trace_test(h)
+
+
 r = RoutingFunction(h; c=[0.02,0.2], g = [a,b, b-0.5])
 ∇r = RoutingGradient(r)
 
@@ -48,7 +52,7 @@ r = RoutingFunction(h; c=[0.02,0.2], g = [a,b, b-0.5])
 d = degree(h)
 
 # Test evaluation
-r([0.01,0.1]) #approximately -94.77
+r([0.01,0.1])
 
 # System used for certified root counting
 FP_allee = System(steady_state, variables = x, parameters = [a; b])
@@ -89,16 +93,15 @@ savefig("figures/allee_original_zoomed_in.svg")
 # ROUTING FUNCTION FROM RADICAL GENERATORS
 
 # Previously computed routing points
-pts = [[0.055589798001425106, 0.20458114869092572]
-    [1.087677447086965, 0.283186049925421]
-    [0.03893320710527537, 0.22760515612129203]
-    [0.0207223762777128, 0.3497569506736974]
-    [0.005192953854625316, 0.3934392610042774]
-    [0.03634241483471314, 0.3616901975928537]
-    [0.0468647920529527, 0.4669511862715351]
+pts = [[0.055589798000619875, 0.2045811486869807], 
+    [1.0876774474050412, 0.2831860499258381], 
+    [0.038933207105874466, 0.22760515612401028], 
+    [0.020722376283910805, 0.349756950729071], 
+    [0.005192953854662725, 0.39343926101839477], 
+    [0.03634241480971159, 0.36169019748921266], 
+    [0.046864792052222624, 0.4669511862494122]
 ]
 
-# Check that all points are critical
 ∇r.(pts)
 
 G, idx, failed_info = partition_of_critical_points(r, pts)

--- a/src/hypersurfaces.jl
+++ b/src/hypersurfaces.jl
@@ -27,6 +27,8 @@ end
 
 degree(h::ProjectedHypersurface) = degree(h.PWS)
 
+trace_test(h::ProjectedHypersurface) = trace_test(h.PWS)
+
 Base.show(io::IO, h::ProjectedHypersurface) = println(io, "Projected hypersurface of degree $(degree(h)) in ambient dimension $(nvariables(h))")
     
 ModelKit.variables(h::ProjectedHypersurface{TC}) where {TC} = h.projection_vars

--- a/src/hypersurfaces.jl
+++ b/src/hypersurfaces.jl
@@ -27,6 +27,16 @@ end
 
 degree(h::ProjectedHypersurface) = degree(h.PWS)
 
+
+"""
+    trace_test(h::ProjectedHypersurface)
+
+Performs a trace test to vertify completeness of the underlying pseduo-witness set and therefore correctness of the degree.
+A value close to zero (e.g., in the order to 1e-16) indicates that the pseudo-witness set is likely complete.
+
+See [`trace_test(::PseudoWitnessSet)`](@ref) for details.
+
+"""
 trace_test(h::ProjectedHypersurface) = trace_test(h.PWS)
 
 Base.show(io::IO, h::ProjectedHypersurface) = println(io, "Projected hypersurface of degree $(degree(h)) in ambient dimension $(nvariables(h))")

--- a/src/hypersurfaces.jl
+++ b/src/hypersurfaces.jl
@@ -1,4 +1,4 @@
-export ProjectedHypersurface, evaluate, gradient, hessian, degree
+export ProjectedHypersurface, evaluate, gradient, hessian, degree, trace_test
 
 struct ProjectedHypersurface{TC} <: HC.AbstractSystem
     PWS::PseudoWitnessSet

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -1,4 +1,4 @@
-export PseudoWitnessSet, degree, total_dim, system
+export PseudoWitnessSet, degree, total_dim, system, trace_test
 struct Line{T<:Number}
     point::Vector{T}
     direction::Vector{T}
@@ -122,6 +122,13 @@ function PseudoWitnessSet(
     )
 end
 
+@doc raw"""
+    u vector of complex intersection points 
+    PWS pseudowitness set
+    p target point for homotopy
+    PWS.tZ contains the coordinates (t,Z) where line (L.direction*t+L.point;Z) intersects V(F)
+"""
+
 function track!(u::Vector{Vector{ComplexF64}}, PWS::PseudoWitnessSet, p::AbstractVector)
     tracker = PWS.tracker
     target_parameters!(tracker, p)
@@ -152,4 +159,42 @@ function get_s_and_Uvals!(Uvals, S, GC, PWS)
     end
 
     nothing
+end
+
+function track_projected_point(PWS::PseudoWitnessSet,p)
+    tZ = deepcopy(PWS.tZ)
+    track!(tZ,PWS,p)
+    b = PWS.L.direction
+    map(tZ) do tz
+        t=first(tz)
+        b*t+p
+    end
+end
+
+function trace_test(PWS::PseudoWitnessSet)
+
+    L = PWS.L
+    p = L.point
+    b = L.direction
+    πW = PWS.πW
+
+    s₀ = sum(πW)
+    v = randn(ComplexF64,PWS.k)
+    #translate our linear space by v
+    p₋₁ = p-v
+    p₁ = p+v
+    πW₋₁ = track_projected_point(PWS,p₋₁)
+    all(PWS.track_report)||return nothing
+
+    πW₁ = track_projected_point(PWS,p₁)
+    all(PWS.track_report)||return nothing
+
+    s₋₁ = sum(πW₋₁)
+    s₁ = sum(πW₁)
+
+    M = [s₋₁ s₀ s₁; 1 1 1]
+    singvals = LinearAlgebra.svdvals(M)
+    trace = singvals[3] / singvals[1]
+
+    trace
 end

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -123,16 +123,19 @@ function PseudoWitnessSet(
 end
 
 @doc raw"""
-    u vector of complex intersection points 
-    PWS pseudowitness set
-    p target point for homotopy
-    PWS.tZ contains the coordinates (t,Z) where line (L.direction*t+L.point;Z) intersects V(F)
-"""
+    track!(u::Vector{Vector{ComplexF64}}, PWS::PseudoWitnessSet, p::AbstractVector)
 
+Given a pseudo-witness set `PWS` and a point `p` in the downstairs space, move the line downstains so that
+it passes through `p` and track the pseudo-witness points. 
+
+The resulting points are stored in `u` and the success of each track is recorded in `PWS.track_report`.
+
+"""
 function track!(u::Vector{Vector{ComplexF64}}, PWS::PseudoWitnessSet, p::AbstractVector)
     tracker = PWS.tracker
     target_parameters!(tracker, p)
-    # Update one tracker instance in place for each target parameter.
+    # PWS.tZ contains the coordinates (t,Z) for the points where the line 
+    # (PWS.L.direction*t+PWS.L.point; Z) intersects V(F)
     for (l, w) in enumerate(PWS.tZ)
             HC.track!(tracker, w, 1)
             copyto!(u[l], tracker.tracker.state.x)

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -184,10 +184,10 @@ function trace_test(PWS::PseudoWitnessSet)
     p₋₁ = p-v
     p₁ = p+v
     πW₋₁ = track_projected_point(PWS,p₋₁)
-    all(PWS.track_report)||return nothing
+    @assert all(PWS.track_report) "Failed paths detected"
 
     πW₁ = track_projected_point(PWS,p₁)
-    all(PWS.track_report)||return nothing
+    @assert all(PWS.track_report) "Failed paths detected"
 
     s₋₁ = sum(πW₋₁)
     s₁ = sum(πW₁)

--- a/src/pseudo_witness_sets.jl
+++ b/src/pseudo_witness_sets.jl
@@ -171,6 +171,22 @@ function track_projected_point(PWS::PseudoWitnessSet,p)
     end
 end
 
+
+"""
+    trace_test(PWS::PseudoWitnessSet)
+
+Performs a trace test for completness of a pseudo-witness set; see [^LRS18] for details.
+
+Returns a trace, which theoretically should be zero if and only if the pseudo-witness set 
+is complete (has all the witness points, meaning that we have correctly computed the degree of the variety).
+
+Since we are working with floating point arithmetic, it will likely not be exactly zero. 
+A very low trace (e.g. on the order of 1e-16) is a strong heutistic indication that the pseudo-witness set is complete, 
+but does not constitute a proof. 
+
+[^LRS18] Leykin, Anton, Jose Israel Rodriguez, and Frank Sottile. "Trace test." Arnold Mathematical Journal 4.1 (2018): 113-125.
+
+"""
 function trace_test(PWS::PseudoWitnessSet)
 
     L = PWS.L

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,9 @@ using Test, Random, ProjectedHypersurfaceRegions, LinearAlgebra, Logging
     F = System([x^2 + a * x + b; 2x + a], variables=[a, b, x])
     h = ProjectedHypersurface(F, [a, b]);
 
+    @test degree(h) == 2
+    @test trace_test(h) < 1e-10
+
     c = [13, 2]
 
     r = RoutingFunction(h; c=c);
@@ -42,6 +45,7 @@ end
     ∇r = RoutingGradient(r)
 
     @test degree(h) == 4
+    @test trace_test(h) < 1e-6
     @test denominator_exponent(r) == 3
 
     # Symbolic routing function
@@ -200,6 +204,7 @@ end
 
     # Degree of the discriminant
     @test degree(h) == 12
+    @test trace_test(h) < 1e-6
 
     h_symbolic = 314928 * w[1]^8 * w[2]^4 + 1259712 * w[1]^7 * w[2]^5 + 1889568 * w[1]^6 * w[2]^6 + 1259712 * w[1]^5 * w[2]^7 +
           314928 * w[1]^4 * w[2]^8 + 139968 * w[1]^10 + 699840 * w[1]^9 * w[2]  + 1277208 * w[1]^8 * w[2]^2 +
@@ -331,7 +336,6 @@ end
 
     PWS = h.PWS
     @test trace_test(PWS) < 1e-10
-
     # Create an artificial failed PWS
     PWS_messed_up = PseudoWitnessSet(PWS.F,
         PWS.k,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -322,3 +322,28 @@ end
     F = System([a^2 - 4*b, (x - a + 1)^2 * (x - a)], variables=[a, b, x])
     @test_logs (:warn, "Irreducible component of higher multiplicity detected in the incidence variety.") match_mode=:any PseudoWitnessSet(F,2)
 end
+
+@testset "Trace test" begin
+
+    @var a b x
+    F = System([x^2 + a * x + b; 2x + a], variables=[a, b, x])
+    h = ProjectedHypersurface(F, [a, b])
+
+    PWS = h.PWS
+    @test trace_test(PWS) < 1e-10
+
+    # Create an artificial failed PWS
+    PWS_messed_up = PseudoWitnessSet(PWS.F,
+        PWS.k,
+        PWS.L,
+        PWS.W[[1]],
+        PWS.πW[[1]],
+        PWS.tZ[[1]],
+        PWS.tracker,
+        PWS.track_report[[1]]
+    )
+
+    @test trace_test(PWS_messed_up) > 1e-6
+
+
+end


### PR DESCRIPTION
Added trace_test function in PseudoWitnessSet. This allows us to check that we have found all pseudo-witness points and hence that the degree is correct. 

See the following paper for more information on trace tests:
https://arxiv.org/pdf/1608.00540

Resolves #62 