### PR TITLE
Add contains method for ProjectedHypersurface

### DIFF
--- a/src/hypersurfaces.jl
+++ b/src/hypersurfaces.jl
@@ -32,6 +32,33 @@ Base.show(io::IO, h::ProjectedHypersurface) = println(io, "Projected hypersurfac
 ModelKit.variables(h::ProjectedHypersurface{TC}) where {TC} = h.projection_vars
 ModelKit.nvariables(h::ProjectedHypersurface{TC}) where {TC} = length(h.projection_vars)
 
+function Base.contains(
+    h::ProjectedHypersurface,
+    p::AbstractVector;
+    atol = sqrt(eps(Float64)),
+    residual_atol = atol,
+)
+    length(p) == nvariables(h) || throw(ArgumentError("Expected $(nvariables(h)) coordinates."))
+
+    PWS, GC = h.PWS, h.GC
+    track!(GC, PWS, p)
+
+    direction_norm = norm(PWS.L.direction)
+    for (track_succeeded, sol) in zip(PWS.track_report, GC.line_hypersurface_intersections)
+        if !track_succeeded || !all(isfinite, sol)
+            continue
+        end
+
+        t = sol[1]
+        w = sol[2:end]
+        if abs(t) * direction_norm <= atol && norm(PWS.F([p; w])) <= residual_atol
+            return true
+        end
+    end
+
+    false
+end
+
 function evaluate(h::ProjectedHypersurface{TC}, x, p = nothing) where {TC}
     PWS, GC = h.PWS, h.GC
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,6 +245,19 @@ end;
     @test isempty(failed_info)
 
 end;
+
+@testset "Projected hypersurface membership" begin
+    Random.seed!(1234)
+    @var a b x
+    F = System([x^2 + a * x + b; 2x + a], variables=[a, b, x])
+    h = ProjectedHypersurface(F, [a, b])
+
+    @test contains(h, [2.0, 1.0])
+    @test !contains(h, [3.0, 1.0])
+    @test_throws ArgumentError contains(h, [2.0])
+end
+
+
 @testset "Hypersurface evaluations for quadratic" begin
 
     # Set up the system


### PR DESCRIPTION
Implement Base.contains to test membership of a projected hypersurface. The method validates input length, invokes track!(GC, PWS, p) and inspects PWS.track_report and GC.line_hypersurface_intersections to find a solution with small line parameter (scaled by direction norm) and small residual (defaults to sqrt(eps(Float64))). Also adds unit tests exercising positive, negative, and argument-error cases for membership checking.

Closes issue #67.