### PR TITLE
Introduce structured result objects for routing and partition APIs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
@@ -26,8 +27,7 @@ SciMLBase = "2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [targets]
-test = ["Test", "Random", "Logging"]
+test = ["Test", "Logging"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
@@ -27,7 +26,8 @@ SciMLBase = "2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [targets]
-test = ["Test", "Logging"]
+test = ["Test", "Random", "Logging"]

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ Routing function for projected hypersurface
 We find the critical points via the `critical_points` function:
 
 ```julia-repl   
-julia> routing_points, res, mon_res = critical_points(r);
-julia> routing_points
+julia> routing_result = critical_points(r);
+
+julia> routing_points(routing_result)
 4-element Vector{Vector{Float64}}:
  [13.040296300414134, 1.993819726256856]
  [3.2168112092392143, 8.082538361382136]
@@ -87,14 +88,14 @@ julia> routing_points
 Finally, we connect the critical points that belong to the same component of the complement:
 
 ```julia-repl
-julia> G, idx, failed_info = partition_of_critical_points(r, routing_points);
+julia> partition_result = partition_of_critical_points(r, routing_result);
 ```
 
-The first output `G` describes the connected components. We see that the first, third and fourth critical points belong to the same connected component, and that the second one belongs to its own component:
+The partitions describe the connected components. We see that the first, third and fourth critical points belong to the same connected component, and that the second one belongs to its own component:
 
 ```julia-repl
-julia> G
-2-element Vector{Any}:
+julia> partitions(partition_result)
+2-element Vector{Vector{Int64}}:
  [1, 3, 4]
  [2]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -73,8 +73,9 @@ Routing function for projected hypersurface
 We find the critical points via the `critical_points` function:
 
 ```julia-repl   
-julia> routing_points, res, mon_res = critical_points(r);
-julia> routing_points
+julia> routing_result = critical_points(r);
+
+julia> routing_points(routing_result)
 4-element Vector{Vector{Float64}}:
  [13.040296300414134, 1.993819726256856]
  [3.2168112092392143, 8.082538361382136]
@@ -85,14 +86,14 @@ julia> routing_points
 Finally, we connect the critical points that belong to the same component of the complement:
 
 ```julia-repl
-julia> G, idx, failed_info = partition_of_critical_points(r, routing_points);
+julia> partition_result = partition_of_critical_points(r, routing_result);
 ```
 
-The first output `G` describes the connected components. We see that the first, third and fourth critical points belong to the same connected component, and that the second one belongs to its own component:
+The partitions describe the connected components. We see that the first, third and fourth critical points belong to the same connected component, and that the second one belongs to its own component:
 
 ```julia-repl
-julia> G
-2-element Vector{Any}:
+julia> partitions(partition_result)
+2-element Vector{Vector{Int64}}:
  [1, 3, 4]
  [2]
 ```

--- a/examples/3RPRv0.jl
+++ b/examples/3RPRv0.jl
@@ -44,10 +44,16 @@ r = RoutingFunction(h; c=center);
 
 # Routing points
 # pts = read_solutions("./results/3RPRv0/routing_points.txt") |> real
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 # Connected components 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 
 time_end_round1 = time()
 println("Computation time for round 1: $(time_end_round1 - time_start_round1) seconds")
@@ -65,15 +71,15 @@ function analyze_and_save_result()
 
     println("Connected components: $(G)")
     println("Indicies: $(idx)")
-    println("Failed info: $(failed_info)")
+    println("Failed info: $(failures)")
     println()
 
     println("Connected components: $(G)")
     println("Indicies: $(idx)")
-    println("Failed info: $(failed_info)")
+    println("Failed info: $(failures)")
     println()
 
-    generate_plot(r, pts, G, idx;
+    generate_plot(r, routing_result, partition_result;
         h=h_symbolic,
         xlims=(-10, 12),
         ylims=(-10, 12)
@@ -83,7 +89,7 @@ function analyze_and_save_result()
     savefig("./figures/3RPR.svg")
     savefig("./figures/3RPR.png")
 
-    generate_plot(r, pts, G, idx;
+    generate_plot(r, routing_result, partition_result;
         h=h_symbolic,
         root_counting_system=root_counting_system,
         markersize=5,
@@ -109,9 +115,15 @@ options = MonodromyOptions(
     parameter_sampler=p -> 100 .* randn(ComplexF64, length(p)), # larger loops
     max_loops_no_progress=10 # stopping criterion
 )
-pts, res, mon_res = critical_points(r, solutions(mon_res), parameters(mon_res), options=options)
+routing_result = critical_points(r, solutions(mon_res), parameters(mon_res), options=options)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 
 time_end_round2 = time()
 println("Additional computation time for round 2: $(time_end_round2 - time_start_round2) seconds")

--- a/examples/3RPRv1.jl
+++ b/examples/3RPRv1.jl
@@ -43,10 +43,16 @@ r = RoutingFunction(h; c=center);
 
 # Routing points
 # pts = read_solutions("./results/3RPRv1/routing_points.txt") |> real
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 # Connected components 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 
 time_end_round1 = time()
 println("Computation time for round 1: $(time_end_round1 - time_start_round1) seconds")
@@ -60,10 +66,10 @@ function analyze_and_save_result()
 
     println("Connected components: $(G)")
     println("Indicies: $(idx)")
-    println("Failed info: $(failed_info)")
+    println("Failed info: $(failures)")
     println()
 
-    generate_plot(r, pts, G, idx;
+    generate_plot(r, routing_result, partition_result;
         root_counting_system=System(f, variables=vcat(p, φ), parameters=projection_variables)
     )
 end
@@ -79,9 +85,15 @@ options = MonodromyOptions(
     parameter_sampler=p -> 100 .* randn(ComplexF64, length(p)), # larger loops
     max_loops_no_progress=10 # stopping criterion
 )
-pts, res, mon_res = critical_points(r, solutions(mon_res), parameters(mon_res), options=options)
+routing_result = critical_points(r, solutions(mon_res), parameters(mon_res), options=options)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 
 time_end_round2 = time()
 println("Additional computation time for round 2: $(time_end_round2 - time_start_round2) seconds")
@@ -94,4 +106,3 @@ if length(solutions(mon_res)) > old_number_of_monodromy_solutions
 else
     println("No new solutions found in the additional monodromy round.")
 end
-

--- a/examples/3RPRv2.jl
+++ b/examples/3RPRv2.jl
@@ -43,10 +43,16 @@ r = RoutingFunction(h; c=center);
 
 # Routing points
 # pts = read_solutions("./results/3RPRv2/routing_points.txt") |> real
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 # Connected components 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 
 time_end_round1 = time()
 println("Computation time for round 1: $(time_end_round1 - time_start_round1) seconds")
@@ -60,10 +66,10 @@ function analyze_and_save_result()
 
     println("Connected components: $(G)")
     println("Indicies: $(idx)")
-    println("Failed info: $(failed_info)")
+    println("Failed info: $(failures)")
     println()
 
-    generate_plot(r, pts, G, idx;
+    generate_plot(r, routing_result, partition_result;
         root_counting_system=System(f, variables=vcat(p, φ), parameters=projection_variables)
     )
 end
@@ -79,9 +85,15 @@ options = MonodromyOptions(
     parameter_sampler=p -> 100 .* randn(ComplexF64, length(p)), # larger loops
     max_loops_no_progress=10 # stopping criterion
 )
-pts, res, mon_res = critical_points(r, solutions(mon_res), parameters(mon_res), options=options)
+routing_result = critical_points(r, solutions(mon_res), parameters(mon_res), options=options)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 
 time_end_round2 = time()
 println("Additional computation time for round 2: $(time_end_round2 - time_start_round2) seconds")
@@ -94,4 +106,3 @@ if length(solutions(mon_res)) > old_number_of_monodromy_solutions
 else
     println("No new solutions found in the additional monodromy round.")
 end
-

--- a/examples/allee_radical.jl
+++ b/examples/allee_radical.jl
@@ -71,7 +71,10 @@ pts_original = [[1.2648270055555684, 0.23668758954766242],
     [0.05913176450416948, 0.46985465616956895]
 ]
 
-G_original, idx_original, failed_info_original = partition_of_critical_points(r_original, pts_original)
+partition_result_original = partition_of_critical_points(r_original, pts_original)
+G_original = partitions(partition_result_original)
+idx_original = morse_indices(partition_result_original)
+failures_original = failed_info(partition_result_original)
 
 pl_original_smaller = generate_plot(
     r_original, pts_original,
@@ -101,7 +104,10 @@ pts = [[0.055589798001425106, 0.20458114869092572]
 # Check that all points are critical
 ∇r.(pts)
 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, pts)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 
 pl_radical_smaller = generate_plot(
     r, pts,

--- a/examples/cubic_three_parameters.jl
+++ b/examples/cubic_three_parameters.jl
@@ -24,16 +24,22 @@ c = 10 .* randn(k)
 r = RoutingFunction(h; c=c)
 
 # Critical points
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 # Connecting critical points
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 println("Connected components: $(G)")
 println("Indicies: $(idx)")
-println("Failed info: $(failed_info)")
+println("Failed info: $(failures)")
 println()
 
-generate_plot(r, pts, G, idx;
+generate_plot(r, routing_result, partition_result;
     root_counting_system=System([x^3 + a * x^2 + b * x + γ], variables=[x], parameters=[a; b; γ])
 )
 

--- a/examples/cubic_two_parameters.jl
+++ b/examples/cubic_two_parameters.jl
@@ -25,7 +25,10 @@ r = RoutingFunction(h; c=c)
 
 # Critical points
 # pts = read_solutions("./results/cubic_two_parameters/routing_points.txt") |> real
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 write_parameters("./results/cubic_two_parameters/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/cubic_two_parameters/monodromy_result.txt", solutions(mon_res))
@@ -33,17 +36,20 @@ write_solutions("./results/cubic_two_parameters/result.txt", solutions(res))
 write_solutions("./results/cubic_two_parameters/routing_points.txt", pts)
 
 # Connecting 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 println("Connected components: $(G)")
 println("Indicies: $(idx)")
-println("Failed info: $(failed_info)")
+println("Failed info: $(failures)")
 println()
 
 write("./results/cubic_two_parameters/connected_components.txt", string(G))
 
 M_x = maximum(p -> abs(p[1]), pts) + 6
 M_y = maximum(p -> abs(p[2]), pts) + 6
-generate_plot(r, pts, G, idx;
+generate_plot(r, routing_result, partition_result;
     h = (x,y) -> 4 * x^3 - x^2 * y^2 - 18 * x * y + 4 * y^3 + 27,
     markersize=6,
     annotation_textsize=5,

--- a/examples/kuramoto.jl
+++ b/examples/kuramoto.jl
@@ -33,10 +33,16 @@ r = RoutingFunction(h; c=C)
 
 # Critical points
 # pts = read_solutions("./results/kuramoto/routing_points.txt") |> real
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 # Connected components
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 
 # Record computation time
 time_end_round1 = time()
@@ -65,10 +71,10 @@ function analyze_and_save_result()
 
     println("Connected components: $(G)")
     println("Indicies: $(idx)")
-    println("Failed info: $(failed_info)")
+    println("Failed info: $(failures)")
     println()
 
-    generate_plot(r, pts, G, idx;
+    generate_plot(r, routing_result, partition_result;
         h=h_symbolic,
         xlims=(-M_x, M_x),
         ylims=(-M_y, M_y),
@@ -79,7 +85,7 @@ function analyze_and_save_result()
     savefig("./figures/kuramoto.svg")
     savefig("./figures/kuramoto.png")
 
-    generate_plot(r, pts, G, idx;
+    generate_plot(r, routing_result, partition_result;
         h=h_symbolic,
         root_counting_system=root_counting_system,
         markersize=6,
@@ -105,7 +111,14 @@ options = MonodromyOptions(
     parameter_sampler=p -> 100 .* randn(ComplexF64, length(p)), # smaller loops
     max_loops_no_progress=15 # change the stopping criterion
 )
-pts, res, mon_res = critical_points(r, solutions(mon_res), parameters(mon_res), options=options)
+routing_result = critical_points(r, solutions(mon_res), parameters(mon_res), options=options)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 time_end_round2 = time()
 println("Additional computation time for round 2: $(time_end_round2 - time_start_round2) seconds")
 println("Total computation time for round 1 and 2: $((time_end_round1 - time_start_round1) + (time_end_round2 - time_start_round2)) seconds")

--- a/examples/old_examples/four_bus.jl
+++ b/examples/old_examples/four_bus.jl
@@ -76,4 +76,7 @@ p0 = evaluate(r, s0) #This returns a vector of NaNs. Upon further inspection,
                      #Note that this is still happening after making the change of restricting to non-singular solutions in the witness set.
 
 ### Routing points 
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)

--- a/examples/quadratic.jl
+++ b/examples/quadratic.jl
@@ -23,7 +23,10 @@ r = RoutingFunction(h; c=c)
 
 # Find the complex critical points 
 # pts = read_solutions("./results/quadratic/routing_points.txt") |> real
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 write_parameters("./results/quadratic/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/quadratic/monodromy_result.txt", solutions(mon_res))
@@ -31,10 +34,13 @@ write_solutions("./results/quadratic/result.txt", solutions(res))
 write_solutions("./results/quadratic/routing_points.txt", pts)
 
 # Connect the critical points
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 println("Connected components: $(G)")
 println("Indicies: $(idx)")
-println("Failed info: $(failed_info)")
+println("Failed info: $(failures)")
 println()
 
 write("./results/quadratic/connected_components.txt", string(G))
@@ -42,7 +48,7 @@ write("./results/quadratic/connected_components.txt", string(G))
 # Analyze root counts and plot result
 M_x = maximum(p -> abs(p[1]), pts) + 4
 M_y = maximum(p -> abs(p[2]), pts) + 3
-generate_plot(r, pts, G, idx;
+generate_plot(r, routing_result, partition_result;
     h=(a, b) -> (a^2 - 4 * b),
     markersize=7,
     annotation_textsize=6,

--- a/examples/quadratic_discriminant_with_lines.jl
+++ b/examples/quadratic_discriminant_with_lines.jl
@@ -17,7 +17,10 @@ e = denominator_exponent(r)
 ∇r = RoutingGradient(r)
 
 # Find the complex critical points 
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 write_parameters("./results/quadratic_discriminant_with_lines/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/quadratic_discriminant_with_lines/monodromy_result.txt", solutions(mon_res))
@@ -25,10 +28,13 @@ write_solutions("./results/quadratic_discriminant_with_lines/result.txt", soluti
 write_solutions("./results/quadratic_discriminant_with_lines/routing_points.txt", pts)
 
 # Connect the critical points
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 println("Connected components: $(G)")
 println("Indicies: $(idx)")
-println("Failed info: $(failed_info)")
+println("Failed info: $(failures)")
 println()
 
 write("./results/quadratic_discriminant_with_lines/connected_components.txt", string(G))
@@ -36,7 +42,7 @@ write("./results/quadratic_discriminant_with_lines/connected_components.txt", st
 ##### Plotting 
 M_x = maximum(p -> abs(p[1]), pts) + 10
 M_y = maximum(p -> abs(p[2]), pts) + 10
-generate_plot(r, pts, G, idx;
+generate_plot(r, routing_result, partition_result;
     h=(a, b) -> (a^2 - 4 * b)*a*b,
     markersize=7,
     arrowstyle=:simple,

--- a/examples/two_discriminants.jl
+++ b/examples/two_discriminants.jl
@@ -21,7 +21,10 @@ r = RoutingFunction([h1, h2]; c=c)
 
 # Critical points
 # pts = read_solutions("./results/two_discriminants/routing_points.txt") |> real
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 write_parameters("./results/two_discriminants/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/two_discriminants/monodromy_result.txt", solutions(mon_res))
@@ -29,17 +32,20 @@ write_solutions("./results/two_discriminants/result.txt", solutions(res))
 write_solutions("./results/two_discriminants/routing_points.txt", pts)
 
 # Connecting 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 println("Connected components: $(G)")
 println("Indicies: $(idx)")
-println("Failed info: $(failed_info)")
+println("Failed info: $(failures)")
 println()
 
 write("./results/two_discriminants/connected_components.txt", string(G))
 
 M_x = maximum(p -> abs(p[1]), pts) + 6
 M_y = maximum(p -> abs(p[2]), pts) + 6
-generate_plot(r, pts, G, idx;
+generate_plot(r, routing_result, partition_result;
     h = (a,b) -> (-4*b-a^2)*(4*a^3 - a^2*b^2 - 18*a*b + 4*b^3 + 27),
     markersize=7,
     arrowstyle=:simple,

--- a/examples/two_parabolas.jl
+++ b/examples/two_parabolas.jl
@@ -21,7 +21,10 @@ r = RoutingFunction([h1, h2]; c=c)
 
 # Critical points
 # pts = read_solutions("./results/two_parabolas/routing_points.txt") |> real
-pts, res, mon_res = critical_points(r)
+routing_result = critical_points(r)
+pts = routing_points(routing_result)
+res = trace_result(routing_result)
+mon_res = monodromy_result(routing_result)
 
 write_parameters("./results/two_parabolas/monodromy_parameters.txt", parameters(mon_res))
 write_solutions("./results/two_parabolas/monodromy_result.txt", solutions(mon_res))
@@ -29,17 +32,20 @@ write_solutions("./results/two_parabolas/result.txt", solutions(res))
 write_solutions("./results/two_parabolas/routing_points.txt", pts)
 
 # Connecting 
-G, idx, failed_info = partition_of_critical_points(r, pts)
+partition_result = partition_of_critical_points(r, routing_result)
+G = partitions(partition_result)
+idx = morse_indices(partition_result)
+failures = failed_info(partition_result)
 println("Connected components: $(G)")
 println("Indicies: $(idx)")
-println("Failed info: $(failed_info)")
+println("Failed info: $(failures)")
 println()
 
 write("./results/two_parabolas/connected_components.txt", string(G))
 
 M_x = maximum(p -> abs(p[1]), pts) + 6
 M_y = maximum(p -> abs(p[2]), pts) + 6
-generate_plot(r, pts, G, idx;
+generate_plot(r, routing_result, partition_result;
     h = (x,y) -> (4*y-x^2)*(-4*y-x^2),
     markersize=7,
     arrowstyle=:simple,

--- a/src/ProjectedHypersurfaceRegions.jl
+++ b/src/ProjectedHypersurfaceRegions.jl
@@ -1,5 +1,5 @@
 module ProjectedHypersurfaceRegions
-using HomotopyContinuation, LinearAlgebra, OrdinaryDiffEq, SciMLBase, LightGraphs, ProgressMeter, Random
+using HomotopyContinuation, LinearAlgebra, OrdinaryDiffEq, SciMLBase, LightGraphs, ProgressMeter
 
 const HC = HomotopyContinuation
 const DE = OrdinaryDiffEq

--- a/src/ProjectedHypersurfaceRegions.jl
+++ b/src/ProjectedHypersurfaceRegions.jl
@@ -1,5 +1,5 @@
 module ProjectedHypersurfaceRegions
-using HomotopyContinuation, LinearAlgebra, OrdinaryDiffEq, SciMLBase, LightGraphs, ProgressMeter
+using HomotopyContinuation, LinearAlgebra, OrdinaryDiffEq, SciMLBase, LightGraphs, ProgressMeter, Random
 
 const HC = HomotopyContinuation
 const DE = OrdinaryDiffEq
@@ -11,6 +11,7 @@ import HomotopyContinuation.taylor!
 import HomotopyContinuation.ModelKit.evaluate
 import HomotopyContinuation.ModelKit.nvariables
 import HomotopyContinuation.ModelKit.variables
+import HomotopyContinuation.ModelKit.parameters
 
 using Reexport: @reexport
 @reexport using HomotopyContinuation
@@ -20,6 +21,7 @@ include("pseudo_witness_sets.jl")
 include("gradient_cache.jl")
 include("hypersurfaces.jl")
 include("routing_functions.jl")
+include("results.jl")
 include("homotopy.jl")
 include("critical_points.jl")
 include("ode_solving.jl")

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -7,6 +7,7 @@ import HomotopyContinuation: MonodromyOptions, UniquePoints, EndgameTracker
     critical_points(r, S0, rhs0; kwargs...)
 
 Find critical points of the routing function using monodromy and gradient flow.
+Returns a [`RoutingPointsResult`](@ref).
 """
 function critical_points(
     r::RoutingFunction,
@@ -25,13 +26,14 @@ function critical_points(
 )
 
     ∇r = RoutingGradient(r)
-
+    rng = Random.MersenneTwister(seed)
 
     # Step 1: Setup monodromy solver
     MS, H, S0, rhs0, k = _setup_monodromy_solver(
         ∇r, S0, rhs0;
         monodromy_at_zero = monodromy_at_zero,
         options = options,
+        rng = rng,
     )
 
     # Step 2: Expand start solutions via Newton's method and gradient flow
@@ -49,6 +51,8 @@ function critical_points(
         MS, H, S0, rhs0, new_pts;
         monodromy_at_zero = monodromy_at_zero,
         start_grid_width = start_grid_width,
+        seed = seed,
+        rng = rng,
     )
 end
 
@@ -68,10 +72,11 @@ function _setup_monodromy_solver(
         parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)),
         max_loops_no_progress = 15
     ),
+    rng = Random.default_rng(),
 )
     k = size(∇r, 2) # number of variables
     p1 = zeros(k)
-    q1 = randn(k)
+    q1 = randn(rng, k)
     H = RoutingPointsHomotopy(∇r, p1, q1)
 
     ### Use monodromy to the system ∇r = rhs0 where we view the right-hand side are the parameters of the system
@@ -98,7 +103,7 @@ function _setup_monodromy_solver(
     #### set up start pair
     if !monodromy_at_zero
         if isnothing(rhs0) || isnothing(S0)
-            s0 = randn(ComplexF64, k)
+            s0 = randn(rng, ComplexF64, k)
             rhs0 = evaluate(∇r, s0)
             S0 = [s0]
         end
@@ -233,7 +238,7 @@ end
     _solve_and_trace(MS, H, S0, rhs0, new_pts; monodromy_at_zero, start_grid_width)
 
 Perform monodromy solving and trace solutions to ∇r=0.
-Returns (routing_points, result, mon_result).
+Returns a [`RoutingPointsResult`](@ref).
 """
 function _solve_and_trace(
     MS::HomotopyContinuation.MonodromySolver,
@@ -243,18 +248,22 @@ function _solve_and_trace(
     new_pts::AbstractVector{<:AbstractVector{<:Number}};
     monodromy_at_zero = false,
     start_grid_width = 5,
+    seed = rand(UInt32),
+    rng = Random.default_rng(),
 )
     ### Monodromy
-    mon_result = monodromy_solve(MS, S0, rhs0, rand(UInt32);)
+    isnothing(seed) || Random.seed!(seed)
+    mon_result = monodromy_solve(MS, S0, rhs0, seed)
+    target_parameters = zeros(ComplexF64, length(rhs0))
 
     ### Trace to ∇r=0
     if !monodromy_at_zero
-        intermediate_rhs = randn(ComplexF64, length(rhs0))
+        intermediate_rhs = randn(rng, ComplexF64, length(rhs0))
         start_parameters!(H, rhs0)
         target_parameters!(H, intermediate_rhs)
         result_intermediate = HomotopyContinuation.solve(H, solutions(mon_result))
         start_parameters!(H, intermediate_rhs)
-        target_parameters!(H, zeros(ComplexF64, length(rhs0)))
+        target_parameters!(H, target_parameters)
         result = HomotopyContinuation.solve(H, result_intermediate)
         routing_points = real_solutions(result)
 
@@ -262,9 +271,9 @@ function _solve_and_trace(
         if start_grid_width > 0
             routing_points = HC.unique_points([routing_points; real.(new_pts)])
         end
-        return routing_points, result, mon_result
+        return RoutingPointsResult(routing_points, result, mon_result, target_parameters)
     else
         routing_points = real_solutions(results(mon_result))
-        return routing_points, mon_result, mon_result
+        return RoutingPointsResult(routing_points, mon_result, mon_result, target_parameters)
     end
 end

--- a/src/critical_points.jl
+++ b/src/critical_points.jl
@@ -22,18 +22,15 @@ function critical_points(
         parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)),
         max_loops_no_progress = 15
     ),
-    seed = rand(UInt32),
 )
 
     ∇r = RoutingGradient(r)
-    rng = Random.MersenneTwister(seed)
 
     # Step 1: Setup monodromy solver
     MS, H, S0, rhs0, k = _setup_monodromy_solver(
         ∇r, S0, rhs0;
         monodromy_at_zero = monodromy_at_zero,
         options = options,
-        rng = rng,
     )
 
     # Step 2: Expand start solutions via Newton's method and gradient flow
@@ -51,8 +48,6 @@ function critical_points(
         MS, H, S0, rhs0, new_pts;
         monodromy_at_zero = monodromy_at_zero,
         start_grid_width = start_grid_width,
-        seed = seed,
-        rng = rng,
     )
 end
 
@@ -72,11 +67,10 @@ function _setup_monodromy_solver(
         parameter_sampler = p -> 10 .* randn(ComplexF64, length(p)),
         max_loops_no_progress = 15
     ),
-    rng = Random.default_rng(),
 )
     k = size(∇r, 2) # number of variables
     p1 = zeros(k)
-    q1 = randn(rng, k)
+    q1 = randn(k)
     H = RoutingPointsHomotopy(∇r, p1, q1)
 
     ### Use monodromy to the system ∇r = rhs0 where we view the right-hand side are the parameters of the system
@@ -103,7 +97,7 @@ function _setup_monodromy_solver(
     #### set up start pair
     if !monodromy_at_zero
         if isnothing(rhs0) || isnothing(S0)
-            s0 = randn(rng, ComplexF64, k)
+            s0 = randn(ComplexF64, k)
             rhs0 = evaluate(∇r, s0)
             S0 = [s0]
         end
@@ -248,17 +242,14 @@ function _solve_and_trace(
     new_pts::AbstractVector{<:AbstractVector{<:Number}};
     monodromy_at_zero = false,
     start_grid_width = 5,
-    seed = rand(UInt32),
-    rng = Random.default_rng(),
 )
     ### Monodromy
-    isnothing(seed) || Random.seed!(seed)
-    mon_result = monodromy_solve(MS, S0, rhs0, seed)
+    mon_result = monodromy_solve(MS, S0, rhs0, rand(UInt32))
     target_parameters = zeros(ComplexF64, length(rhs0))
 
     ### Trace to ∇r=0
     if !monodromy_at_zero
-        intermediate_rhs = randn(rng, ComplexF64, length(rhs0))
+        intermediate_rhs = randn(ComplexF64, length(rhs0))
         start_parameters!(H, rhs0)
         target_parameters!(H, intermediate_rhs)
         result_intermediate = HomotopyContinuation.solve(H, solutions(mon_result))

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -37,7 +37,7 @@ function _index_list(∇r, crit_pts)
         index, unstable_eigenvectors, flag = index_unstable_eigenvector!(u, U, ∇r, a)
         if flag == true
             flag_prime = true
-            return nothing, nothing, nothing, flag_prime
+            return nothing, nothing, flag_prime
         end
 
         push!(index_list, index)
@@ -64,7 +64,7 @@ end
 
 function partition_of_critical_points(
     r::RoutingFunction,
-    crit_pts::Vector{Vector{Float64}},
+    crit_pts::AbstractVector{<:AbstractVector{<:Real}},
     epsilon::Float64 = 1e-6,
     reltol::Float64 = 1e-6,
     abstol::Float64 = 1e-9,
@@ -75,7 +75,7 @@ function partition_of_critical_points(
     index_list, unstable_eigenvector_list, flag_prime = _index_list(∇r, crit_pts)
     if flag_prime == true
         @warn "The Hessian is almost singular for some critical points"
-        return nothing
+        return PartitionResult(Vector{Vector{Int}}(), nothing, [], :singular_hessian)
     end
 
 
@@ -90,7 +90,7 @@ function partition_of_critical_points(
 
     if count_index_0 == 1
         # we do not need to do any path tracking in this case
-        return [critical_points_indices], [], []
+        return PartitionResult([critical_points_indices], Int[], [], :success)
     end
 
 
@@ -205,5 +205,13 @@ function partition_of_critical_points(
     for par in partition
         push!(partition_critical_point_indices, @view(critical_points_indices[par]))
     end
-    return partition_critical_point_indices, index_list, failed_info_list
+    code = isempty(failed_info_list) ? :success : :partial_success
+    return PartitionResult(partition_critical_point_indices, index_list, failed_info_list, code)
 end
+
+partition_of_critical_points(
+    r::RoutingFunction,
+    result::RoutingPointsResult,
+    args...;
+    kwargs...,
+) = partition_of_critical_points(r, routing_points(result), args...; kwargs...)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -90,9 +90,8 @@ function partition_of_critical_points(
 
     if count_index_0 == 1
         # we do not need to do any path tracking in this case
-        return PartitionResult([critical_points_indices], Int[], [], :success)
+        return PartitionResult([critical_points_indices], index_list, [], :success)
     end
-
 
     failed_info_list = []
     ProgressMeter.@showprogress for i = 1:length(index_list)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -288,3 +288,21 @@ function generate_plot(
         legendfontsize = 6,
     )
 end
+
+function generate_plot(
+    r::RoutingFunction,
+    routing_result::RoutingPointsResult,
+    partition_result::PartitionResult;
+    kwargs...,
+)
+    isnothing(morse_indices(partition_result)) &&
+        error("Cannot generate a plot from a partition result with no Morse indices.")
+
+    generate_plot(
+        r,
+        routing_points(routing_result),
+        partitions(partition_result),
+        morse_indices(partition_result);
+        kwargs...,
+    )
+end

--- a/src/results.jl
+++ b/src/results.jl
@@ -1,0 +1,159 @@
+export RoutingPointsResult,
+    PartitionResult,
+    routing_points,
+    trace_result,
+    monodromy_result,
+    return_code,
+    partitions,
+    morse_indices,
+    failed_info,
+    npartitions
+
+import HomotopyContinuation:
+    solutions, real_solutions, nsolutions, results, nresults, seed
+
+"""
+    RoutingPointsResult
+
+Result returned by [`critical_points`](@ref). Use [`routing_points`](@ref) for the
+real routing points, [`trace_result`](@ref) for the final trace result, and
+[`monodromy_result`](@ref) for the underlying monodromy computation.
+The pair `solutions(result), parameters(result)` represents the routing points as
+solutions to `∇r = 0`; use `monodromy_result(result)` for the monodromy start pair.
+"""
+struct RoutingPointsResult{P,T,M,Q}
+    routing_points::P
+    trace_result::T
+    monodromy_result::M
+    target_parameters::Q
+end
+function RoutingPointsResult(routing_points, trace_result, monodromy_result)
+    if isempty(routing_points)
+        nparameters = isnothing(monodromy_result) ? 0 : length(parameters(monodromy_result))
+    else
+        nparameters = length(first(routing_points))
+    end
+    RoutingPointsResult(
+        routing_points,
+        trace_result,
+        monodromy_result,
+        zeros(ComplexF64, nparameters),
+    )
+end
+
+"""
+    routing_points(result::RoutingPointsResult)
+
+Return the real critical points used for routing.
+"""
+routing_points(R::RoutingPointsResult) = R.routing_points
+
+"""
+    trace_result(result::RoutingPointsResult)
+
+Return the final HomotopyContinuation result obtained by tracing to ∇r = 0.
+"""
+trace_result(R::RoutingPointsResult) = R.trace_result
+
+"""
+    monodromy_result(result::RoutingPointsResult)
+
+Return the underlying monodromy computation result.
+"""
+monodromy_result(R::RoutingPointsResult) = R.monodromy_result
+
+"""
+    return_code(result)
+
+Return a symbolic status code for a routing or partition result.
+"""
+return_code(R::RoutingPointsResult) =
+    isnothing(monodromy_result(R)) ? :unknown : monodromy_result(R).returncode
+
+solutions(R::RoutingPointsResult) = routing_points(R)
+real_solutions(R::RoutingPointsResult; kwargs...) = routing_points(R)
+nsolutions(R::RoutingPointsResult) = length(routing_points(R))
+results(R::RoutingPointsResult; kwargs...) = results(trace_result(R); kwargs...)
+nresults(R::RoutingPointsResult; kwargs...) = nresults(trace_result(R); kwargs...)
+parameters(R::RoutingPointsResult) = R.target_parameters
+seed(R::RoutingPointsResult) = isnothing(monodromy_result(R)) ? nothing : seed(monodromy_result(R))
+
+"""
+    PartitionResult
+
+Result returned by [`partition_of_critical_points`](@ref). Use
+[`partitions`](@ref) for connected components, [`morse_indices`](@ref) for the
+critical point indices, and [`failed_info`](@ref) for failed connection attempts.
+"""
+struct PartitionResult{P,I,F}
+    partitions::P
+    morse_indices::I
+    failed_info::F
+    return_code::Symbol
+end
+
+"""
+    partitions(result::PartitionResult)
+
+Return the connected components as vectors of routing point indices.
+"""
+partitions(R::PartitionResult) = R.partitions
+
+"""
+    morse_indices(result::PartitionResult)
+
+Return the Morse index computed for each routing point, or `nothing` if the
+partition failed before indices were available.
+"""
+morse_indices(R::PartitionResult) = R.morse_indices
+
+"""
+    failed_info(result::PartitionResult)
+
+Return information collected from failed connection attempts.
+"""
+failed_info(R::PartitionResult) = R.failed_info
+return_code(R::PartitionResult) = R.return_code
+
+"""
+    npartitions(result::PartitionResult)
+
+Return the number of connected components in the partition result.
+"""
+npartitions(R::PartitionResult) = length(partitions(R))
+
+function _plural(noun::AbstractString, n::Integer)
+    n == 1 ? noun : string(noun, "s")
+end
+
+function Base.show(io::IO, R::RoutingPointsResult)
+    npts = nsolutions(R)
+    header = "RoutingPointsResult with $npts $(_plural("routing point", npts))"
+    println(io, header)
+    println(io, "="^length(header))
+    println(io, "• return_code → :", return_code(R))
+    if isnothing(trace_result(R))
+        println(io, "• raw trace results → unknown")
+    else
+        ntrace = nresults(R)
+        println(io, "• $ntrace raw trace $(_plural("result", ntrace))")
+    end
+    if isnothing(monodromy_result(R))
+        println(io, "• monodromy solutions → unknown")
+    else
+        nmon = nsolutions(monodromy_result(R))
+        println(io, "• $nmon monodromy $(_plural("solution", nmon))")
+    end
+    print(io, "• random_seed → ", sprint(show, seed(R)))
+end
+
+function Base.show(io::IO, R::PartitionResult)
+    npars = npartitions(R)
+    nfailures = length(failed_info(R))
+    header = "PartitionResult with $npars $(_plural("partition", npars))"
+    println(io, header)
+    println(io, "="^length(header))
+    println(io, "• return_code → :", return_code(R))
+    println(io, "• $(nfailures) failed $(_plural("connection", nfailures))")
+    print(io, "• morse_indices → ", isnothing(morse_indices(R)) ? "not computed" : length(morse_indices(R)))
+end

--- a/src/results.jl
+++ b/src/results.jl
@@ -62,14 +62,6 @@ Return the underlying monodromy computation result.
 """
 monodromy_result(R::RoutingPointsResult) = R.monodromy_result
 
-"""
-    return_code(result)
-
-Return a symbolic status code for a routing or partition result.
-"""
-return_code(R::RoutingPointsResult) =
-    isnothing(monodromy_result(R)) ? :unknown : monodromy_result(R).returncode
-
 solutions(R::RoutingPointsResult) = routing_points(R)
 real_solutions(R::RoutingPointsResult; kwargs...) = routing_points(R)
 nsolutions(R::RoutingPointsResult) = length(routing_points(R))
@@ -86,7 +78,7 @@ critical point indices, and [`failed_info`](@ref) for failed connection attempts
 """
 struct PartitionResult{P,I,F}
     partitions::P
-    morse_indices::I
+    morse_indices::I # TODO: this is a strange output to expose to users, since it is indexing yet another list you must reference. Considering changing this to a Dict or something.
     failed_info::F
     return_code::Symbol
 end
@@ -112,6 +104,12 @@ morse_indices(R::PartitionResult) = R.morse_indices
 Return information collected from failed connection attempts.
 """
 failed_info(R::PartitionResult) = R.failed_info
+
+"""
+    return_code(result::PartitionResult)
+
+Return a symbolic status code for a partition result.
+"""
 return_code(R::PartitionResult) = R.return_code
 
 """
@@ -130,7 +128,6 @@ function Base.show(io::IO, R::RoutingPointsResult)
     header = "RoutingPointsResult with $npts $(_plural("routing point", npts))"
     println(io, header)
     println(io, "="^length(header))
-    println(io, "• return_code → :", return_code(R))
     if isnothing(trace_result(R))
         println(io, "• raw trace results → unknown")
     else
@@ -151,7 +148,7 @@ function Base.show(io::IO, R::PartitionResult)
     header = "PartitionResult with $npars $(_plural("partition", npars))"
     println(io, header)
     println(io, "="^length(header))
-    println(io, "• return_code → :", return_code(R))
+    println(io, "• return_code → :$(return_code(R))")
     println(io, "• $(nfailures) failed $(_plural("connection", nfailures))")
     print(io, "• morse_indices → ", isnothing(morse_indices(R)) ? "not computed" : length(morse_indices(R)))
 end

--- a/src/results.jl
+++ b/src/results.jl
@@ -10,7 +10,7 @@ export RoutingPointsResult,
     npartitions
 
 import HomotopyContinuation:
-    solutions, real_solutions, nsolutions, results, nresults, seed
+    solutions, real_solutions, nsolutions, results, nresults
 
 """
     RoutingPointsResult
@@ -76,7 +76,6 @@ nsolutions(R::RoutingPointsResult) = length(routing_points(R))
 results(R::RoutingPointsResult; kwargs...) = results(trace_result(R); kwargs...)
 nresults(R::RoutingPointsResult; kwargs...) = nresults(trace_result(R); kwargs...)
 parameters(R::RoutingPointsResult) = R.target_parameters
-seed(R::RoutingPointsResult) = isnothing(monodromy_result(R)) ? nothing : seed(monodromy_result(R))
 
 """
     PartitionResult
@@ -139,12 +138,11 @@ function Base.show(io::IO, R::RoutingPointsResult)
         println(io, "• $ntrace raw trace $(_plural("result", ntrace))")
     end
     if isnothing(monodromy_result(R))
-        println(io, "• monodromy solutions → unknown")
+        print(io, "• monodromy solutions → unknown")
     else
         nmon = nsolutions(monodromy_result(R))
-        println(io, "• $nmon monodromy $(_plural("solution", nmon))")
+        print(io, "• $nmon monodromy $(_plural("solution", nmon))")
     end
-    print(io, "• random_seed → ", sprint(show, seed(R)))
 end
 
 function Base.show(io::IO, R::PartitionResult)

--- a/task.md
+++ b/task.md
@@ -1,3 +1,0 @@
-
-## Idea
-Instead of having a result object called `PartitionResult`, there should be a 

--- a/task.md
+++ b/task.md
@@ -1,0 +1,3 @@
+
+## Idea
+Instead of having a result object called `PartitionResult`, there should be a 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,8 +94,22 @@ end
 
     # Check critical points
     options = MonodromyOptions(target_solutions_count = 2)
-    pts, res0, mon_res = critical_points(r, start_grid_width=0, options=options)    
-    @test all(norm.(∇r_symbolic.(solutions(res0))) .< 1e-12)
+    routing_result = critical_points(r, start_grid_width=0, options=options, seed=0x12345678)
+    repeated_routing_result =
+        critical_points(r, start_grid_width=0, options=options, seed=0x12345678)
+    @test routing_result isa RoutingPointsResult
+    @test solutions(routing_result) == routing_points(routing_result)
+    @test real_solutions(routing_result) == routing_points(routing_result)
+    @test parameters(routing_result) == zeros(ComplexF64, size(∇r, 1))
+    @test all(norm(evaluate(∇r, z, parameters(routing_result))) < 1e-12 for z in solutions(routing_result))
+    @test trace_result(routing_result) isa Result
+    @test monodromy_result(routing_result) isa MonodromyResult
+    @test seed(routing_result) == seed(monodromy_result(routing_result))
+    @test parameters(monodromy_result(routing_result)) == parameters(monodromy_result(repeated_routing_result))
+    @test routing_points(routing_result) == routing_points(repeated_routing_result)
+    @test !applicable(iterate, routing_result)
+    @test !isempty(sprint(show, routing_result))
+    @test all(norm.(∇r_symbolic.(solutions(trace_result(routing_result)))) .< 1e-12)
 
     pl = generate_plot(
         r,
@@ -146,8 +160,8 @@ end;
 
     # Check critical points
     options = MonodromyOptions(target_solutions_count = 2)
-    pts, res0, mon_res = critical_points(r, start_grid_width=0, options=options)   
-    @test all(norm.(∇r_symbolic.(solutions(res0))) .< 1e-12)
+    routing_result = critical_points(r, start_grid_width=0, options=options)
+    @test all(norm.(∇r_symbolic.(solutions(trace_result(routing_result)))) .< 1e-12)
 
 end;
 
@@ -175,8 +189,8 @@ end;
 
     # Check critical points
     options = MonodromyOptions(target_solutions_count = 2)
-    pts, res0, mon_res = critical_points(r, start_grid_width=0, options=options)   
-    @test all(norm.(∇r_symbolic.(solutions(res0))) .< 1e-12)
+    routing_result = critical_points(r, start_grid_width=0, options=options)
+    @test all(norm.(∇r_symbolic.(solutions(trace_result(routing_result)))) .< 1e-12)
 
 end
 
@@ -238,11 +252,18 @@ end;
 
     @test all(norm.(∇r.(pts)) .< 1e-12) 
 
-    G, idx, failed_info = partition_of_critical_points(r, pts)
+    partition_result = partition_of_critical_points(r, pts)
+    partition_result_from_routing_result =
+        partition_of_critical_points(r, RoutingPointsResult(pts, nothing, nothing))
 
-    @test sort(G) == [[1, 2, 4], [3]]
-    @test idx == [1, 0, 0, 0]
-    @test isempty(failed_info)
+    @test partition_result isa PartitionResult
+    @test sort(partitions(partition_result)) == [[1, 2, 4], [3]]
+    @test morse_indices(partition_result) == [1, 0, 0, 0]
+    @test isempty(failed_info(partition_result))
+    @test return_code(partition_result) == :success
+    @test partitions(partition_result_from_routing_result) == partitions(partition_result)
+    @test !applicable(iterate, partition_result)
+    @test !isempty(sprint(show, partition_result))
 
 end;
 @testset "Hypersurface evaluations for quadratic" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,9 +103,11 @@ end
     @test all(norm(evaluate(∇r, z, parameters(routing_result))) < 1e-12 for z in solutions(routing_result))
     @test trace_result(routing_result) isa Result
     @test monodromy_result(routing_result) isa MonodromyResult
-    @test return_code(routing_result) == monodromy_result(routing_result).returncode
+    @test !applicable(return_code, routing_result)
     @test !applicable(iterate, routing_result)
-    @test !isempty(sprint(show, routing_result))
+    routing_display = sprint(show, routing_result)
+    @test !isempty(routing_display)
+    @test !occursin("return_code", routing_display)
     @test all(norm.(∇r_symbolic.(solutions(trace_result(routing_result)))) .< 1e-12)
 
     pl = generate_plot(
@@ -260,7 +262,10 @@ end;
     @test return_code(partition_result) == :success
     @test partitions(partition_result_from_routing_result) == partitions(partition_result)
     @test !applicable(iterate, partition_result)
-    @test !isempty(sprint(show, partition_result))
+    partition_display = sprint(show, partition_result)
+    @test !isempty(partition_display)
+    @test occursin("return_code → :success", partition_display)
+    @test !occursin("::success", partition_display)
 
 end;
 @testset "Hypersurface evaluations for quadratic" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,9 +94,8 @@ end
 
     # Check critical points
     options = MonodromyOptions(target_solutions_count = 2)
-    routing_result = critical_points(r, start_grid_width=0, options=options, seed=0x12345678)
-    repeated_routing_result =
-        critical_points(r, start_grid_width=0, options=options, seed=0x12345678)
+    @test_throws MethodError critical_points(r, start_grid_width=0, options=options, seed=0x12345678)
+    routing_result = critical_points(r, start_grid_width=0, options=options)
     @test routing_result isa RoutingPointsResult
     @test solutions(routing_result) == routing_points(routing_result)
     @test real_solutions(routing_result) == routing_points(routing_result)
@@ -104,9 +103,7 @@ end
     @test all(norm(evaluate(∇r, z, parameters(routing_result))) < 1e-12 for z in solutions(routing_result))
     @test trace_result(routing_result) isa Result
     @test monodromy_result(routing_result) isa MonodromyResult
-    @test seed(routing_result) == seed(monodromy_result(routing_result))
-    @test parameters(monodromy_result(routing_result)) == parameters(monodromy_result(repeated_routing_result))
-    @test routing_points(routing_result) == routing_points(repeated_routing_result)
+    @test return_code(routing_result) == monodromy_result(routing_result).returncode
     @test !applicable(iterate, routing_result)
     @test !isempty(sprint(show, routing_result))
     @test all(norm.(∇r_symbolic.(solutions(trace_result(routing_result)))) .< 1e-12)


### PR DESCRIPTION
- Add `RoutingPointsResult` and `PartitionResult` return types with accessor functions for routing points, trace results, monodromy results, partitions, Morse indices, failures, and return codes.
- Update `critical_points` and `partition_of_critical_points` to return structured results instead of positional tuples.
- Add `generate_plot` support for the new result objects.
- Update README, docs, examples, and tests to use the new accessor-based API.
- Remove explicit `seed` handling in favor of the global RNG.


Closes #65.